### PR TITLE
Allow for  RPC methods to contain dots

### DIFF
--- a/jsonrpc/src/server/mod.rs
+++ b/jsonrpc/src/server/mod.rs
@@ -249,7 +249,8 @@ where
         }
 
         let srvc_name = srvc_method[0].to_string();
-        let method_name = srvc_method[1].to_string();
+        // Method name is allowed to contain dots
+        let method_name = srvc_method[1..].join(".");
 
         SanityCheckResult::NewReq(NewRequest {
             srvc_name,


### PR DESCRIPTION
There is nothing in the standard that prevents the use of dots in the RPC method name. Instead of dealing with "subservices", let's keep it simple and allow for dots in the method name.
This makes it possible to create endpoints like `service.my.wonderful.method`.