### PR TITLE
Update karyon net codec API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,6 @@ dependencies = [
 name = "karyon_net"
 version = "0.1.8"
 dependencies = [
- "async-channel 2.3.1",
  "async-trait",
  "async-tungstenite",
  "bincode",

--- a/core/src/async_runtime/executor.rs
+++ b/core/src/async_runtime/executor.rs
@@ -28,7 +28,7 @@ impl Executor {
 
     #[cfg(feature = "tokio")]
     pub fn handle(&self) -> &tokio::runtime::Handle {
-        return self.inner.handle();
+        self.inner.handle()
     }
 }
 

--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -5,12 +5,12 @@ A fast and lightweight async implementation of [JSON-RPC
 
 features: 
 - Supports TCP, TLS, WebSocket, and Unix protocols.
-- Uses `smol`(async-std) as the async runtime, but also supports `tokio` via the 
+- Uses `smol`(async-std) as the async runtime, with support for `tokio` via the 
   `tokio` feature.
-- Allows registration of multiple services (structs) of different types on a
-  single server.
-- Supports pub/sub  
-- Allows passing an `async_executors::Executor` or tokio's `Runtime` when building
+- Enables the registration of multiple services (structs) on a single server.
+- Offers support for custom JSON codec.
+- Includes support for pub/sub.  
+- Allows the use of an `async_executors::Executor` or `tokio::Runtime` when building
   the server.
 
 
@@ -31,7 +31,7 @@ use serde_json::Value;
 use smol::stream::StreamExt;
 
 use karyon_jsonrpc::{
-    RPCError, Server, Client, rpc_impl, rpc_pubsub_impl, SubscriptionID, Channel
+    RPCError, Server, ServerBuilder, ClientBuilder, rpc_impl, rpc_pubsub_impl, SubscriptionID, Channel
 };
 
 struct HelloWorld {}
@@ -84,7 +84,7 @@ async {
     let service = Arc::new(HelloWorld {});
     // Creates a new server
 
-    let server = Server::builder("tcp://127.0.0.1:60000")
+    let server = ServerBuilder::new("tcp://127.0.0.1:60000")
         .expect("create new server builder")
         .service(service.clone())
         .pubsub_service(service)
@@ -101,7 +101,7 @@ async {
 // Client
 async {
     // Creates a new client
-    let client = Client::builder("tcp://127.0.0.1:60000")
+    let client = ClientBuilder::new("tcp://127.0.0.1:60000")
         .expect("create new client builder")
         .build()
         .await

--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -31,7 +31,8 @@ use serde_json::Value;
 use smol::stream::StreamExt;
 
 use karyon_jsonrpc::{
-    RPCError, Server, ServerBuilder, ClientBuilder, rpc_impl, rpc_pubsub_impl, SubscriptionID, Channel
+    error::RPCError, server::{Server, ServerBuilder, Channel}, client::ClientBuilder,
+    rpc_impl, rpc_pubsub_impl, message::SubscriptionID,
 };
 
 struct HelloWorld {}

--- a/jsonrpc/examples/client.rs
+++ b/jsonrpc/examples/client.rs
@@ -4,7 +4,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use smol::Timer;
 
-use karyon_jsonrpc::Client;
+use karyon_jsonrpc::ClientBuilder;
 
 #[derive(Deserialize, Serialize)]
 struct Req {
@@ -18,7 +18,7 @@ struct Pong {}
 fn main() {
     env_logger::init();
     smol::future::block_on(async {
-        let client = Client::builder("tcp://127.0.0.1:6000")
+        let client = ClientBuilder::new("tcp://127.0.0.1:6000")
             .expect("Create client builder")
             .build()
             .await

--- a/jsonrpc/examples/client.rs
+++ b/jsonrpc/examples/client.rs
@@ -4,7 +4,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use smol::Timer;
 
-use karyon_jsonrpc::ClientBuilder;
+use karyon_jsonrpc::client::ClientBuilder;
 
 #[derive(Deserialize, Serialize)]
 struct Req {

--- a/jsonrpc/examples/client_custom_codec.rs
+++ b/jsonrpc/examples/client_custom_codec.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use log::info;
+use serde::{Deserialize, Serialize};
+use smol::Timer;
+
+use karyon_jsonrpc::{
+    client::ClientBuilder,
+    codec::{Codec, Decoder, Encoder},
+    error::Error,
+};
+
+#[derive(Deserialize, Serialize)]
+struct Req {
+    x: u32,
+    y: u32,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+struct Pong {}
+
+#[derive(Clone)]
+pub struct CustomJsonCodec {}
+
+impl Codec for CustomJsonCodec {
+    type Message = serde_json::Value;
+    type Error = Error;
+}
+
+impl Encoder for CustomJsonCodec {
+    type EnMessage = serde_json::Value;
+    type EnError = Error;
+    fn encode(
+        &self,
+        src: &Self::EnMessage,
+        dst: &mut [u8],
+    ) -> std::result::Result<usize, Self::EnError> {
+        let msg = match serde_json::to_string(src) {
+            Ok(m) => m,
+            Err(err) => return Err(Error::Encode(err.to_string())),
+        };
+        let buf = msg.as_bytes();
+        dst[..buf.len()].copy_from_slice(buf);
+        Ok(buf.len())
+    }
+}
+
+impl Decoder for CustomJsonCodec {
+    type DeMessage = serde_json::Value;
+    type DeError = Error;
+    fn decode(
+        &self,
+        src: &mut [u8],
+    ) -> std::result::Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
+        let de = serde_json::Deserializer::from_slice(src);
+        let mut iter = de.into_iter::<serde_json::Value>();
+
+        let item = match iter.next() {
+            Some(Ok(item)) => item,
+            Some(Err(ref e)) if e.is_eof() => return Ok(None),
+            Some(Err(e)) => return Err(Error::Decode(e.to_string())),
+            None => return Ok(None),
+        };
+
+        Ok(Some((iter.byte_offset(), item)))
+    }
+}
+
+fn main() {
+    env_logger::init();
+    smol::future::block_on(async {
+        let client = ClientBuilder::new_with_codec("tcp://127.0.0.1:6000", CustomJsonCodec {})
+            .expect("Create client builder")
+            .build()
+            .await
+            .expect("Create rpc client");
+
+        loop {
+            Timer::after(Duration::from_millis(100)).await;
+            let result: Pong = client
+                .call("Calc.ping", ())
+                .await
+                .expect("Call Calc.ping method");
+            info!("Ping result:  {:?}", result);
+        }
+    });
+}

--- a/jsonrpc/examples/pubsub_client.rs
+++ b/jsonrpc/examples/pubsub_client.rs
@@ -4,13 +4,13 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use smol::Timer;
 
-use karyon_jsonrpc::Client;
+use karyon_jsonrpc::ClientBuilder;
 
 #[derive(Deserialize, Serialize, Debug)]
 struct Pong {}
 
 async fn run_client() {
-    let client = Client::builder("tcp://127.0.0.1:6000")
+    let client = ClientBuilder::new("tcp://127.0.0.1:6000")
         .expect("Create client builder")
         .build()
         .await

--- a/jsonrpc/examples/pubsub_client.rs
+++ b/jsonrpc/examples/pubsub_client.rs
@@ -4,7 +4,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use smol::Timer;
 
-use karyon_jsonrpc::ClientBuilder;
+use karyon_jsonrpc::client::ClientBuilder;
 
 #[derive(Deserialize, Serialize, Debug)]
 struct Pong {}

--- a/jsonrpc/examples/pubsub_server.rs
+++ b/jsonrpc/examples/pubsub_server.rs
@@ -6,7 +6,10 @@ use serde_json::Value;
 
 use karyon_core::async_util::sleep;
 use karyon_jsonrpc::{
-    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, ServerBuilder,
+    error::RPCError,
+    message::SubscriptionID,
+    rpc_impl, rpc_pubsub_impl,
+    server::{channel::Channel, ServerBuilder},
 };
 
 struct Calc {}

--- a/jsonrpc/examples/pubsub_server.rs
+++ b/jsonrpc/examples/pubsub_server.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use karyon_core::async_util::sleep;
 use karyon_jsonrpc::{
-    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, Server,
+    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, ServerBuilder,
 };
 
 struct Calc {}
@@ -69,7 +69,7 @@ fn main() {
         let calc = Arc::new(Calc {});
 
         // Creates a new server
-        let server = Server::builder("tcp://127.0.0.1:6000")
+        let server = ServerBuilder::new("tcp://127.0.0.1:6000")
             .expect("Create a new server builder")
             .service(calc.clone())
             .pubsub_service(calc)

--- a/jsonrpc/examples/server.rs
+++ b/jsonrpc/examples/server.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use karyon_core::async_util::sleep;
-use karyon_jsonrpc::{rpc_impl, RPCError, ServerBuilder};
+use karyon_jsonrpc::{error::RPCError, rpc_impl, server::ServerBuilder};
 
 struct Calc {
     version: String,

--- a/jsonrpc/examples/server.rs
+++ b/jsonrpc/examples/server.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use karyon_core::async_util::sleep;
-use karyon_jsonrpc::{rpc_impl, RPCError, Server};
+use karyon_jsonrpc::{rpc_impl, RPCError, ServerBuilder};
 
 struct Calc {
     version: String,
@@ -49,7 +49,7 @@ fn main() {
         };
 
         // Creates a new server
-        let server = Server::builder("tcp://127.0.0.1:6000")
+        let server = ServerBuilder::new("tcp://127.0.0.1:6000")
             .expect("Create a new server builder")
             .service(Arc::new(calc))
             .build()

--- a/jsonrpc/examples/server_custom_codec.rs
+++ b/jsonrpc/examples/server_custom_codec.rs
@@ -1,0 +1,99 @@
+use std::{sync::Arc, time::Duration};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use karyon_core::async_util::sleep;
+
+use karyon_jsonrpc::{
+    codec::{Codec, Decoder, Encoder},
+    error::{Error, RPCError},
+    rpc_impl,
+    server::ServerBuilder,
+};
+
+struct Calc {}
+
+#[derive(Deserialize, Serialize)]
+struct Req {
+    x: u32,
+    y: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Pong {}
+
+#[rpc_impl]
+impl Calc {
+    async fn ping(&self, _params: Value) -> Result<Value, RPCError> {
+        Ok(serde_json::json!(Pong {}))
+    }
+}
+
+#[derive(Clone)]
+pub struct CustomJsonCodec {}
+
+impl Codec for CustomJsonCodec {
+    type Message = serde_json::Value;
+    type Error = Error;
+}
+
+impl Encoder for CustomJsonCodec {
+    type EnMessage = serde_json::Value;
+    type EnError = Error;
+    fn encode(
+        &self,
+        src: &Self::EnMessage,
+        dst: &mut [u8],
+    ) -> std::result::Result<usize, Self::EnError> {
+        let msg = match serde_json::to_string(src) {
+            Ok(m) => m,
+            Err(err) => return Err(Error::Encode(err.to_string())),
+        };
+        let buf = msg.as_bytes();
+        dst[..buf.len()].copy_from_slice(buf);
+        Ok(buf.len())
+    }
+}
+
+impl Decoder for CustomJsonCodec {
+    type DeMessage = serde_json::Value;
+    type DeError = Error;
+    fn decode(
+        &self,
+        src: &mut [u8],
+    ) -> std::result::Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
+        let de = serde_json::Deserializer::from_slice(src);
+        let mut iter = de.into_iter::<serde_json::Value>();
+
+        let item = match iter.next() {
+            Some(Ok(item)) => item,
+            Some(Err(ref e)) if e.is_eof() => return Ok(None),
+            Some(Err(e)) => return Err(Error::Decode(e.to_string())),
+            None => return Ok(None),
+        };
+
+        Ok(Some((iter.byte_offset(), item)))
+    }
+}
+
+fn main() {
+    env_logger::init();
+    smol::block_on(async {
+        // Register the Calc service
+        let calc = Calc {};
+
+        // Creates a new server
+        let server = ServerBuilder::new_with_codec("tcp://127.0.0.1:6000", CustomJsonCodec {})
+            .expect("Create a new server builder")
+            .service(Arc::new(calc))
+            .build()
+            .await
+            .expect("start a new server");
+
+        // Start the server
+        server.start();
+
+        sleep(Duration::MAX).await;
+    });
+}

--- a/jsonrpc/examples/tokio_server/src/main.rs
+++ b/jsonrpc/examples/tokio_server/src/main.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use karyon_jsonrpc::{
-    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, ServerBuilder,
+    error::RPCError,
+    message::SubscriptionID,
+    rpc_impl, rpc_pubsub_impl,
+    server::{Channel, ServerBuilder},
 };
 
 struct Calc {

--- a/jsonrpc/examples/tokio_server/src/main.rs
+++ b/jsonrpc/examples/tokio_server/src/main.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use karyon_jsonrpc::{
-    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, Server,
+    message::SubscriptionID, rpc_impl, rpc_pubsub_impl, Channel, RPCError, ServerBuilder,
 };
 
 struct Calc {
@@ -84,7 +84,7 @@ async fn main() {
     });
 
     // Creates a new server
-    let server = Server::builder("ws://127.0.0.1:6000")
+    let server = ServerBuilder::new("ws://127.0.0.1:6000")
         .expect("Create a new server builder")
         .service(calc.clone())
         .pubsub_service(calc)

--- a/jsonrpc/impl/src/lib.rs
+++ b/jsonrpc/impl/src/lib.rs
@@ -53,11 +53,11 @@ pub fn rpc_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let item: TokenStream2 = item.into();
     quote! {
-        impl karyon_jsonrpc::RPCService for #self_ty {
+        impl karyon_jsonrpc::server::RPCService for #self_ty {
             fn get_method(
                 &self,
                 name: &str
-            ) -> Option<karyon_jsonrpc::RPCMethod> {
+            ) -> Option<karyon_jsonrpc::server::RPCMethod> {
                 match name {
                 #(#impl_methods)*
                     _ => None,
@@ -105,7 +105,7 @@ pub fn rpc_pubsub_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
         |m| quote! {
             stringify!(#m) => {
                 Some(Box::new(
-                    move |chan: std::sync::Arc<karyon_jsonrpc::Channel>, method: String, params: serde_json::Value| {
+                    move |chan: std::sync::Arc<karyon_jsonrpc::server::channel::Channel>, method: String, params: serde_json::Value| {
                     Box::pin(self.#m(chan, method, params))
                 }))
             },
@@ -114,11 +114,11 @@ pub fn rpc_pubsub_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let item: TokenStream2 = item.into();
     quote! {
-        impl karyon_jsonrpc::PubSubRPCService for #self_ty {
+        impl karyon_jsonrpc::server::PubSubRPCService for #self_ty {
             fn get_pubsub_method(
                 &self,
                 name: &str
-            ) -> Option<karyon_jsonrpc::PubSubRPCMethod> {
+            ) -> Option<karyon_jsonrpc::server::PubSubRPCMethod> {
                 match name {
                 #(#impl_methods)*
                     _ => None,

--- a/jsonrpc/src/client/builder.rs
+++ b/jsonrpc/src/client/builder.rs
@@ -1,18 +1,15 @@
 use std::sync::Arc;
 
-#[cfg(feature = "tcp")]
-use karyon_net::Endpoint;
-use karyon_net::ToEndpoint;
-
 #[cfg(feature = "tls")]
 use karyon_net::async_rustls::rustls;
 
 use crate::{
     codec::{ClonableJsonCodec, JsonCodec},
     error::Result,
+    net::ToEndpoint,
 };
 #[cfg(feature = "tcp")]
-use crate::{error::Error, net::TcpConfig};
+use crate::{error::Error, net::Endpoint, net::TcpConfig};
 
 use super::{Client, ClientConfig};
 

--- a/jsonrpc/src/client/builder.rs
+++ b/jsonrpc/src/client/builder.rs
@@ -7,10 +7,12 @@ use karyon_net::ToEndpoint;
 #[cfg(feature = "tls")]
 use karyon_net::async_rustls::rustls;
 
-use crate::codec::{ClonableJsonCodec, JsonCodec};
-use crate::Result;
+use crate::{
+    codec::{ClonableJsonCodec, JsonCodec},
+    error::Result,
+};
 #[cfg(feature = "tcp")]
-use crate::{Error, TcpConfig};
+use crate::{error::Error, net::TcpConfig};
 
 use super::{Client, ClientConfig};
 
@@ -32,7 +34,7 @@ impl ClientBuilder<JsonCodec> {
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::ClientBuilder;
+    /// use karyon_jsonrpc::client::ClientBuilder;
     ///  
     /// async {
     ///     let builder = ClientBuilder::new("ws://127.0.0.1:3000")
@@ -64,7 +66,10 @@ where
     /// use async_tungstenite::tungstenite::Message;
     /// use serde_json::Value;
     ///
-    /// use karyon_jsonrpc::{ClientBuilder, codec::{Codec, Decoder, Encoder}, Error, Result};
+    /// use karyon_jsonrpc::{
+    ///     client::ClientBuilder, codec::{Codec, Decoder, Encoder},
+    ///     error::{Error, Result}
+    /// };
     ///
     /// #[derive(Clone)]
     /// pub struct CustomJsonCodec {}
@@ -178,7 +183,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::ClientBuilder;
+    /// use karyon_jsonrpc::client::ClientBuilder;
     ///  
     /// async {
     ///     let client = ClientBuilder::new("ws://127.0.0.1:3000")
@@ -204,7 +209,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::ClientBuilder;
+    /// use karyon_jsonrpc::client::ClientBuilder;
     ///  
     /// async {
     ///     let client = ClientBuilder::new("ws://127.0.0.1:3000")
@@ -224,7 +229,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::{ClientBuilder, TcpConfig};
+    /// use karyon_jsonrpc::{client::ClientBuilder, net::TcpConfig};
     ///  
     /// async {
     ///     let tcp_config = TcpConfig::default();
@@ -255,7 +260,7 @@ where
     /// # Example
     ///
     /// ```ignore
-    /// use karyon_jsonrpc::ClientBuilder;
+    /// use karyon_jsonrpc::client::ClientBuilder;
     /// use futures_rustls::rustls;
     ///  
     /// async {
@@ -293,7 +298,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::{ClientBuilder, TcpConfig};
+    /// use karyon_jsonrpc::{client::ClientBuilder, net::TcpConfig};
     ///  
     /// async {
     ///     let tcp_config = TcpConfig::default();

--- a/jsonrpc/src/client/builder.rs
+++ b/jsonrpc/src/client/builder.rs
@@ -51,21 +51,33 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::Client;
-    /// use karyon_net::{codec::{Codec, Decoder, Encoder}, Error, Result};
     ///
+    /// #[cfg(feature = "ws")]
+    /// use karyon_jsonrpc::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
+    /// #[cfg(feature = "ws")]
+    /// use async_tungstenite::tungstenite::Message;
     /// use serde_json::Value;
+    ///
+    /// use karyon_jsonrpc::{Client, codec::{Codec, Decoder, Encoder}, Error, Result};
     ///
     /// #[derive(Clone)]
     /// pub struct CustomJsonCodec {}
     ///
     /// impl Codec for CustomJsonCodec {
-    ///     type Item = serde_json::Value;
+    ///     type Message = serde_json::Value;
+    ///     type Error = Error;
+    /// }
+    ///
+    /// #[cfg(feature = "ws")]
+    /// impl WebSocketCodec for CustomJsonCodec {
+    ///     type Message = serde_json::Value;
+    ///     type Error = Error;
     /// }
     ///
     /// impl Encoder for CustomJsonCodec {
-    ///     type EnItem = serde_json::Value;
-    ///     fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    ///     type EnMessage = serde_json::Value;
+    ///     type EnError = Error;
+    ///     fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
     ///         let msg = match serde_json::to_string(src) {
     ///             Ok(m) => m,
     ///             Err(err) => return Err(Error::Encode(err.to_string())),
@@ -77,8 +89,9 @@ where
     /// }
     ///
     /// impl Decoder for CustomJsonCodec {
-    ///     type DeItem = serde_json::Value;
-    ///     fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    ///     type DeMessage = serde_json::Value;
+    ///     type DeError = Error;
+    ///     fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
     ///         let de = serde_json::Deserializer::from_slice(src);
     ///         let mut iter = de.into_iter::<serde_json::Value>();
     ///
@@ -91,6 +104,43 @@ where
     ///
     ///         Ok(Some((iter.byte_offset(), item)))
     ///     }
+    /// }
+    ///
+    /// #[cfg(feature = "ws")]
+    /// impl WebSocketEncoder for CustomJsonCodec {
+    ///     type EnMessage = serde_json::Value;
+    ///     type EnError = Error;
+    ///
+    ///     fn encode(&self, src: &Self::EnMessage) -> Result<Message> {
+    ///         let msg = match serde_json::to_string(src) {
+    ///             Ok(m) => m,
+    ///             Err(err) => return Err(Error::Encode(err.to_string())),
+    ///         };
+    ///         Ok(Message::Text(msg))
+    ///     }
+    /// }
+    ///
+    /// #[cfg(feature = "ws")]
+    /// impl WebSocketDecoder for CustomJsonCodec {
+    ///     type DeMessage = serde_json::Value;
+    ///     type DeError = Error;
+    ///     fn decode(&self, src: &Message) -> Result<Option<Self::DeMessage>> {
+    ///          match src {
+    ///              Message::Text(s) => match serde_json::from_str(s) {
+    ///                  Ok(m) => Ok(Some(m)),
+    ///                  Err(err) => Err(Error::Decode(err.to_string())),
+    ///              },
+    ///              Message::Binary(s) => match serde_json::from_slice(s) {
+    ///                  Ok(m) => Ok(m),
+    ///                  Err(err) => Err(Error::Decode(err.to_string())),
+    ///              },
+    ///              Message::Close(_) => Err(Error::IO(std::io::ErrorKind::ConnectionAborted.into())),
+    ///              m => Err(Error::Decode(format!(
+    ///                  "Receive unexpected message: {:?}",
+    ///                  m
+    ///              ))),
+    ///          }
+    ///      }
     /// }
     ///
     /// async {
@@ -127,7 +177,7 @@ pub struct ClientBuilder<C> {
 
 impl<C> ClientBuilder<C>
 where
-    C: ClonableJsonCodec,
+    C: ClonableJsonCodec + 'static,
 {
     /// Set timeout for receiving messages, in milliseconds. Requests will
     /// fail if it takes longer.

--- a/jsonrpc/src/client/message_dispatcher.rs
+++ b/jsonrpc/src/client/message_dispatcher.rs
@@ -4,7 +4,10 @@ use async_channel::{Receiver, Sender};
 
 use karyon_core::async_runtime::lock::Mutex;
 
-use crate::{message, Error, Result};
+use crate::{
+    error::{Error, Result},
+    message,
+};
 
 use super::RequestID;
 

--- a/jsonrpc/src/client/mod.rs
+++ b/jsonrpc/src/client/mod.rs
@@ -33,12 +33,14 @@ use karyon_core::{
 use crate::codec::ClonableJsonCodec;
 
 use crate::{
+    error::{Error, Result},
     message::{self, SubscriptionID},
-    Error, Result,
 };
 
-use message_dispatcher::MessageDispatcher;
+pub use builder::ClientBuilder;
 pub use subscriptions::Subscription;
+
+use message_dispatcher::MessageDispatcher;
 use subscriptions::Subscriptions;
 
 type RequestID = u32;

--- a/jsonrpc/src/client/mod.rs
+++ b/jsonrpc/src/client/mod.rs
@@ -214,8 +214,7 @@ where
         let conn: Conn<serde_json::Value, Error> = match endpoint {
             #[cfg(feature = "tcp")]
             Endpoint::Tcp(..) => Box::new(
-                karyon_net::tcp::dial(&endpoint, self.config.tcp_config.clone(), codec)
-                    .await?,
+                karyon_net::tcp::dial(&endpoint, self.config.tcp_config.clone(), codec).await?,
             ),
             #[cfg(feature = "tls")]
             Endpoint::Tls(..) => match &self.config.tls_config {

--- a/jsonrpc/src/client/subscriptions.rs
+++ b/jsonrpc/src/client/subscriptions.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use karyon_core::async_runtime::lock::Mutex;
 
 use crate::{
+    error::{Error, Result},
     message::{Notification, NotificationResult, SubscriptionID},
-    Error, Result,
 };
 
 /// A subscription established when the client's subscribe to a method

--- a/jsonrpc/src/codec.rs
+++ b/jsonrpc/src/codec.rs
@@ -1,20 +1,29 @@
 #[cfg(feature = "ws")]
 use async_tungstenite::tungstenite::Message;
 
-use karyon_net::{
-    codec::{Codec, Decoder, Encoder},
-    Error, Result,
-};
+pub use karyon_net::codec::{Codec, Decoder, Encoder};
 
 #[cfg(feature = "ws")]
-use karyon_net::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
+pub use karyon_net::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
 
+use crate::Error;
+
+#[cfg(not(feature = "ws"))]
+pub trait ClonableJsonCodec: Codec<Message = serde_json::Value, Error = Error> + Clone {}
+#[cfg(not(feature = "ws"))]
+impl<T: Codec<Message = serde_json::Value, Error = Error> + Clone> ClonableJsonCodec for T {}
+
+#[cfg(feature = "ws")]
 pub trait ClonableJsonCodec:
-    Codec<Item = serde_json::Value, DeItem = serde_json::Value, EnItem = serde_json::Value> + Clone
+    Codec<Message = serde_json::Value, Error = Error>
+    + WebSocketCodec<Message = serde_json::Value, Error = Error>
+    + Clone
 {
 }
+#[cfg(feature = "ws")]
 impl<
-        T: Codec<Item = serde_json::Value, DeItem = serde_json::Value, EnItem = serde_json::Value>
+        T: Codec<Message = serde_json::Value, Error = Error>
+            + WebSocketCodec<Message = serde_json::Value, Error = Error>
             + Clone,
     > ClonableJsonCodec for T
 {
@@ -24,12 +33,14 @@ impl<
 pub struct JsonCodec {}
 
 impl Codec for JsonCodec {
-    type Item = serde_json::Value;
+    type Message = serde_json::Value;
+    type Error = Error;
 }
 
 impl Encoder for JsonCodec {
-    type EnItem = serde_json::Value;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = serde_json::Value;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize, Self::EnError> {
         let msg = match serde_json::to_string(src) {
             Ok(m) => m,
             Err(err) => return Err(Error::Encode(err.to_string())),
@@ -41,8 +52,9 @@ impl Encoder for JsonCodec {
 }
 
 impl Decoder for JsonCodec {
-    type DeItem = serde_json::Value;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = serde_json::Value;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
         let de = serde_json::Deserializer::from_slice(src);
         let mut iter = de.into_iter::<serde_json::Value>();
 
@@ -62,14 +74,17 @@ impl Decoder for JsonCodec {
 pub struct WsJsonCodec {}
 
 #[cfg(feature = "ws")]
-impl WebSocketCodec for WsJsonCodec {
-    type Item = serde_json::Value;
+impl WebSocketCodec for JsonCodec {
+    type Message = serde_json::Value;
+    type Error = Error;
 }
 
 #[cfg(feature = "ws")]
-impl WebSocketEncoder for WsJsonCodec {
-    type EnItem = serde_json::Value;
-    fn encode(&self, src: &Self::EnItem) -> Result<Message> {
+impl WebSocketEncoder for JsonCodec {
+    type EnMessage = serde_json::Value;
+    type EnError = Error;
+
+    fn encode(&self, src: &Self::EnMessage) -> Result<Message, Self::EnError> {
         let msg = match serde_json::to_string(src) {
             Ok(m) => m,
             Err(err) => return Err(Error::Encode(err.to_string())),
@@ -79,9 +94,11 @@ impl WebSocketEncoder for WsJsonCodec {
 }
 
 #[cfg(feature = "ws")]
-impl WebSocketDecoder for WsJsonCodec {
-    type DeItem = serde_json::Value;
-    fn decode(&self, src: &Message) -> Result<Option<Self::DeItem>> {
+impl WebSocketDecoder for JsonCodec {
+    type DeMessage = serde_json::Value;
+    type DeError = Error;
+
+    fn decode(&self, src: &Message) -> Result<Option<Self::DeMessage>, Self::DeError> {
         match src {
             Message::Text(s) => match serde_json::from_str(s) {
                 Ok(m) => Ok(Some(m)),

--- a/jsonrpc/src/codec.rs
+++ b/jsonrpc/src/codec.rs
@@ -6,7 +6,7 @@ pub use karyon_net::codec::{Codec, Decoder, Encoder};
 #[cfg(feature = "ws")]
 pub use karyon_net::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
 
-use crate::Error;
+use crate::error::Error;
 
 #[cfg(not(feature = "ws"))]
 pub trait ClonableJsonCodec: Codec<Message = serde_json::Value, Error = Error> + Clone {}

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -8,11 +8,17 @@ pub enum Error {
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
-    #[error("Call Error: code: {0} msg: {1}")]
+    #[error("Call Error: code: {0} - msg: {1}")]
     CallError(i32, String),
 
-    #[error("Subscribe Error: code: {0} msg: {1}")]
+    #[error("Subscribe Error: code: {0} - msg: {1}")]
     SubscribeError(i32, String),
+
+    #[error("Encode Error: {0}")]
+    Encode(String),
+
+    #[error("Decode Error: {0}")]
+    Decode(String),
 
     #[error("Invalid Message Error: {0}")]
     InvalidMsg(&'static str),
@@ -26,16 +32,16 @@ pub enum Error {
     #[error("Tls config is required")]
     TLSConfigRequired,
 
-    #[error("Receive close message from connection: {0}")]
+    #[error("Receive Close Message From Connection: {0}")]
     CloseConnection(String),
 
-    #[error("Subscription not found: {0}")]
+    #[error("Subscription Not Found: {0}")]
     SubscriptionNotFound(String),
 
-    #[error("Subscription exceeds the maximum buffer size")]
+    #[error("Subscription Exceeds The Maximum Buffer Size")]
     SubscriptionBufferFull,
 
-    #[error("Subscription closed")]
+    #[error("Subscription Closed")]
     SubscriptionClosed,
 
     #[error("ClientDisconnected")]
@@ -46,6 +52,10 @@ pub enum Error {
 
     #[error("Channel send  Error: {0}")]
     ChannelSend(String),
+
+    #[cfg(feature = "ws")]
+    #[error(transparent)]
+    WebSocket(#[from] async_tungstenite::tungstenite::Error),
 
     #[error("Unexpected Error: {0}")]
     General(&'static str),

--- a/jsonrpc/src/lib.rs
+++ b/jsonrpc/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod client;
-mod codec;
+pub mod codec;
 mod error;
 pub mod message;
 mod server;
@@ -19,7 +19,7 @@ pub use server::{
 
 pub use karyon_jsonrpc_macro::{rpc_impl, rpc_pubsub_impl};
 
-pub use karyon_net::Endpoint;
+pub use karyon_net::{Addr, Endpoint};
 
 #[cfg(feature = "tcp")]
 pub use karyon_net::tcp::TcpConfig;

--- a/jsonrpc/src/lib.rs
+++ b/jsonrpc/src/lib.rs
@@ -1,25 +1,10 @@
 #![doc = include_str!("../README.md")]
 
-mod client;
+pub mod client;
 pub mod codec;
-mod error;
+pub mod error;
 pub mod message;
-mod server;
-
-pub use client::{builder::ClientBuilder, Client};
-pub use error::{Error, RPCError, RPCResult, Result};
-pub use message::SubscriptionID;
-pub use server::{
-    builder::ServerBuilder,
-    channel::{Channel, Subscription},
-    pubsub_service::{PubSubRPCMethod, PubSubRPCService},
-    service::{RPCMethod, RPCService},
-    Server,
-};
+pub mod net;
+pub mod server;
 
 pub use karyon_jsonrpc_macro::{rpc_impl, rpc_pubsub_impl};
-
-pub use karyon_net::{Addr, Endpoint};
-
-#[cfg(feature = "tcp")]
-pub use karyon_net::tcp::TcpConfig;

--- a/jsonrpc/src/message.rs
+++ b/jsonrpc/src/message.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::RPCError;
+use crate::error::RPCError;
 
 pub type ID = u64;
 

--- a/jsonrpc/src/net.rs
+++ b/jsonrpc/src/net.rs
@@ -1,0 +1,4 @@
+pub use karyon_net::{Addr, Endpoint, ToEndpoint};
+
+#[cfg(feature = "tcp")]
+pub use karyon_net::tcp::TcpConfig;

--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -3,16 +3,21 @@ use std::{collections::HashMap, sync::Arc};
 use karyon_core::async_runtime::Executor;
 
 #[cfg(feature = "tcp")]
-use karyon_net::Endpoint;
-use karyon_net::ToEndpoint;
+use crate::net::Endpoint;
 
 #[cfg(feature = "tls")]
 use karyon_net::async_rustls::rustls;
 
-use crate::codec::{ClonableJsonCodec, JsonCodec};
 #[cfg(feature = "tcp")]
 use crate::{error::Error, net::TcpConfig};
-use crate::{error::Result, server::PubSubRPCService, server::RPCService};
+
+use crate::{
+    codec::{ClonableJsonCodec, JsonCodec},
+    error::Result,
+    net::ToEndpoint,
+    server::PubSubRPCService,
+    server::RPCService,
+};
 
 use super::{Server, ServerConfig};
 

--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -11,8 +11,8 @@ use karyon_net::async_rustls::rustls;
 
 use crate::codec::{ClonableJsonCodec, JsonCodec};
 #[cfg(feature = "tcp")]
-use crate::{Error, TcpConfig};
-use crate::{PubSubRPCService, RPCService, Result};
+use crate::{error::Error, net::TcpConfig};
+use crate::{error::Result, server::PubSubRPCService, server::RPCService};
 
 use super::{Server, ServerConfig};
 
@@ -41,7 +41,7 @@ where
     /// use serde_json::Value;
     /// #[cfg(feature = "ws")]
     /// use karyon_jsonrpc::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
-    /// use karyon_jsonrpc::{Server, ServerBuilder, codec::{Codec, Decoder, Encoder, }, Error, Result};
+    /// use karyon_jsonrpc::{server::ServerBuilder, codec::{Codec, Decoder, Encoder, }, error::{Error, Result}};
     ///
     ///
     /// #[derive(Clone)]
@@ -161,7 +161,7 @@ where
     ///
     /// use serde_json::Value;
     ///
-    /// use karyon_jsonrpc::{Server, rpc_impl, RPCError, ServerBuilder};
+    /// use karyon_jsonrpc::{rpc_impl, error::RPCError, server::ServerBuilder};
     ///
     /// struct Ping {}
     ///
@@ -195,8 +195,8 @@ where
     /// use serde_json::Value;
     ///
     /// use karyon_jsonrpc::{
-    ///     Server, rpc_impl, rpc_pubsub_impl, RPCError, Channel, SubscriptionID,
-    ///     ServerBuilder,
+    ///     rpc_impl, rpc_pubsub_impl, error::RPCError, message::SubscriptionID,
+    ///     server::{ServerBuilder, Channel},
     /// };
     ///
     /// struct Ping {}
@@ -254,7 +254,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::{ServerBuilder, TcpConfig};
+    /// use karyon_jsonrpc::{server::ServerBuilder, net::TcpConfig};
     ///
     /// async {
     ///     let tcp_config = TcpConfig::default();
@@ -333,7 +333,8 @@ impl ServerBuilder<JsonCodec> {
     /// # Example
     ///
     /// ```
-    /// use karyon_jsonrpc::ServerBuilder;
+    /// use karyon_jsonrpc::server::ServerBuilder;
+    ///
     /// async {
     ///     let server = ServerBuilder::new("ws://127.0.0.1:3000")
     ///         .expect("Create a new server builder")

--- a/jsonrpc/src/server/channel.rs
+++ b/jsonrpc/src/server/channel.rs
@@ -2,7 +2,10 @@ use std::sync::{Arc, Weak};
 
 use karyon_core::{async_runtime::lock::Mutex, util::random_32};
 
-use crate::{message::SubscriptionID, Error, Result};
+use crate::{
+    error::{Error, Result},
+    message::SubscriptionID,
+};
 
 #[derive(Debug)]
 pub(crate) struct NewNotification {

--- a/jsonrpc/src/server/mod.rs
+++ b/jsonrpc/src/server/mod.rs
@@ -15,16 +15,18 @@ use karyon_core::{
 
 #[cfg(feature = "tls")]
 use karyon_net::async_rustls::rustls;
-#[cfg(feature = "tcp")]
-use karyon_net::tcp::TcpConfig;
 #[cfg(feature = "ws")]
 use karyon_net::ws::ServerWsConfig;
-use karyon_net::{Conn, Endpoint, Listener};
+use karyon_net::{Conn, Listener};
+
+#[cfg(feature = "tcp")]
+use crate::net::TcpConfig;
 
 use crate::{
     codec::ClonableJsonCodec,
     error::{Error, Result},
     message,
+    net::Endpoint,
 };
 
 pub use builder::ServerBuilder;

--- a/jsonrpc/src/server/mod.rs
+++ b/jsonrpc/src/server/mod.rs
@@ -21,9 +21,17 @@ use karyon_net::tcp::TcpConfig;
 use karyon_net::ws::ServerWsConfig;
 use karyon_net::{Conn, Endpoint, Listener};
 
-use crate::{codec::ClonableJsonCodec, message, Error, PubSubRPCService, RPCService, Result};
+use crate::{
+    codec::ClonableJsonCodec,
+    error::{Error, Result},
+    message,
+};
 
-use channel::Channel;
+pub use builder::ServerBuilder;
+pub use channel::Channel;
+pub use pubsub_service::{PubSubRPCMethod, PubSubRPCService};
+pub use service::{RPCMethod, RPCService};
+
 use response_queue::ResponseQueue;
 
 pub const INVALID_REQUEST_ERROR_MSG: &str = "Invalid request";

--- a/jsonrpc/src/server/pubsub_service.rs
+++ b/jsonrpc/src/server/pubsub_service.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
-use crate::RPCResult;
+use crate::error::RPCResult;
 
 use super::channel::Channel;
 

--- a/jsonrpc/src/server/service.rs
+++ b/jsonrpc/src/server/service.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin};
 
-use crate::RPCResult;
+use crate::error::RPCResult;
 
 /// Represents the RPC method
 pub type RPCMethod<'a> = Box<dyn Fn(serde_json::Value) -> RPCMethodOutput<'a> + Send + 'a>;

--- a/jsonrpc/tests/rpc_impl.rs
+++ b/jsonrpc/tests/rpc_impl.rs
@@ -1,4 +1,4 @@
-use karyon_jsonrpc::{rpc_impl, RPCError, RPCService};
+use karyon_jsonrpc::{error::RPCError, rpc_impl, server::RPCService};
 use serde_json::Value;
 
 #[test]

--- a/jsonrpc/tests/rpc_pubsub_impl.rs
+++ b/jsonrpc/tests/rpc_pubsub_impl.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use karyon_jsonrpc::{rpc_pubsub_impl, Channel, PubSubRPCService, RPCError};
+use karyon_jsonrpc::{
+    error::RPCError,
+    rpc_pubsub_impl,
+    server::{Channel, PubSubRPCService},
+};
 use serde_json::Value;
 
 #[test]

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -44,7 +44,6 @@ bincode = { workspace = true, features = ["derive"] }
 
 # async
 async-trait = { workspace = true }
-async-channel = { workspace = true }
 futures-util = { workspace = true, features = ["sink"], optional = true }
 pin-project-lite = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["io-util"], optional = true }

--- a/net/examples/tcp_codec.rs
+++ b/net/examples/tcp_codec.rs
@@ -4,27 +4,30 @@ use karyon_core::async_util::sleep;
 
 use karyon_net::{
     codec::{Codec, Decoder, Encoder},
-    tcp, ConnListener, Connection, Endpoint, Result,
+    tcp, ConnListener, Connection, Endpoint, Error, Result,
 };
 
 #[derive(Clone)]
 struct NewLineCodec {}
 
 impl Codec for NewLineCodec {
-    type Item = String;
+    type Message = String;
+    type Error = Error;
 }
 
 impl Encoder for NewLineCodec {
-    type EnItem = String;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = String;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         dst[..src.len()].copy_from_slice(src.as_bytes());
         Ok(src.len())
     }
 }
 
 impl Decoder for NewLineCodec {
-    type DeItem = String;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = String;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         match src.iter().position(|&b| b == b'\n') {
             Some(i) => Ok(Some((i + 1, String::from_utf8(src[..i].to_vec()).unwrap()))),
             None => Ok(None),

--- a/net/examples/tcp_codec_tokio/src/main.rs
+++ b/net/examples/tcp_codec_tokio/src/main.rs
@@ -4,27 +4,30 @@ use karyon_core::async_util::sleep;
 
 use karyon_net::{
     codec::{Codec, Decoder, Encoder},
-    tcp, ConnListener, Connection, Endpoint, Result,
+    tcp, ConnListener, Connection, Endpoint, Error, Result,
 };
 
 #[derive(Clone)]
 struct NewLineCodec {}
 
 impl Codec for NewLineCodec {
-    type Item = String;
+    type Message = String;
+    type Error = Error;
 }
 
 impl Encoder for NewLineCodec {
-    type EnItem = String;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = String;
+    type EncodeError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         dst[..src.len()].copy_from_slice(src.as_bytes());
         Ok(src.len())
     }
 }
 
 impl Decoder for NewLineCodec {
-    type DeItem = String;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = String;
+    type DecodeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         match src.iter().position(|&b| b == b'\n') {
             Some(i) => Ok(Some((i + 1, String::from_utf8(src[..i].to_vec()).unwrap()))),
             None => Ok(None),

--- a/net/examples/tcp_codec_tokio/src/main.rs
+++ b/net/examples/tcp_codec_tokio/src/main.rs
@@ -17,7 +17,7 @@ impl Codec for NewLineCodec {
 
 impl Encoder for NewLineCodec {
     type EnMessage = String;
-    type EncodeError = Error;
+    type EnError = Error;
     fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         dst[..src.len()].copy_from_slice(src.as_bytes());
         Ok(src.len())
@@ -26,7 +26,7 @@ impl Encoder for NewLineCodec {
 
 impl Decoder for NewLineCodec {
     type DeMessage = String;
-    type DecodeError = Error;
+    type DeError = Error;
     fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         match src.iter().position(|&b| b == b'\n') {
             Some(i) => Ok(Some((i + 1, String::from_utf8(src[..i].to_vec()).unwrap()))),

--- a/net/src/codec/bytes_codec.rs
+++ b/net/src/codec/bytes_codec.rs
@@ -1,25 +1,28 @@
 use crate::{
     codec::{Codec, Decoder, Encoder},
-    Result,
+    Error, Result,
 };
 
 #[derive(Clone)]
 pub struct BytesCodec {}
 impl Codec for BytesCodec {
-    type Item = Vec<u8>;
+    type Message = Vec<u8>;
+    type Error = Error;
 }
 
 impl Encoder for BytesCodec {
-    type EnItem = Vec<u8>;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = Vec<u8>;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         dst[..src.len()].copy_from_slice(src);
         Ok(src.len())
     }
 }
 
 impl Decoder for BytesCodec {
-    type DeItem = Vec<u8>;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = Vec<u8>;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         if src.is_empty() {
             Ok(None)
         } else {

--- a/net/src/codec/length_codec.rs
+++ b/net/src/codec/length_codec.rs
@@ -2,7 +2,7 @@ use karyon_core::util::{decode, encode_into_slice};
 
 use crate::{
     codec::{Codec, Decoder, Encoder},
-    Result,
+    Error, Result,
 };
 
 /// The size of the message length.
@@ -11,12 +11,14 @@ const MSG_LENGTH_SIZE: usize = std::mem::size_of::<u32>();
 #[derive(Clone)]
 pub struct LengthCodec {}
 impl Codec for LengthCodec {
-    type Item = Vec<u8>;
+    type Message = Vec<u8>;
+    type Error = Error;
 }
 
 impl Encoder for LengthCodec {
-    type EnItem = Vec<u8>;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = Vec<u8>;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         let length_buf = &mut [0; MSG_LENGTH_SIZE];
         encode_into_slice(&(src.len() as u32), length_buf)?;
         dst[..MSG_LENGTH_SIZE].copy_from_slice(length_buf);
@@ -26,8 +28,9 @@ impl Encoder for LengthCodec {
 }
 
 impl Decoder for LengthCodec {
-    type DeItem = Vec<u8>;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = Vec<u8>;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         if src.len() < MSG_LENGTH_SIZE {
             return Ok(None);
         }

--- a/net/src/codec/websocket.rs
+++ b/net/src/codec/websocket.rs
@@ -1,23 +1,24 @@
-use crate::Result;
 use async_tungstenite::tungstenite::Message;
 
 pub trait WebSocketCodec:
-    WebSocketDecoder<DeItem = Self::Item>
-    + WebSocketEncoder<EnItem = Self::Item>
+    WebSocketDecoder<DeMessage = Self::Message, DeError = Self::Error>
+    + WebSocketEncoder<EnMessage = Self::Message, EnError = Self::Error>
     + Send
     + Sync
-    + 'static
     + Unpin
 {
-    type Item: Send + Sync;
+    type Message: Send + Sync;
+    type Error;
 }
 
 pub trait WebSocketEncoder {
-    type EnItem;
-    fn encode(&self, src: &Self::EnItem) -> Result<Message>;
+    type EnMessage;
+    type EnError;
+    fn encode(&self, src: &Self::EnMessage) -> std::result::Result<Message, Self::EnError>;
 }
 
 pub trait WebSocketDecoder {
-    type DeItem;
-    fn decode(&self, src: &Message) -> Result<Option<Self::DeItem>>;
+    type DeMessage;
+    type DeError;
+    fn decode(&self, src: &Message) -> std::result::Result<Option<Self::DeMessage>, Self::DeError>;
 }

--- a/net/src/error.rs
+++ b/net/src/error.rs
@@ -7,43 +7,18 @@ pub enum Error {
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
-    #[error("Try from endpoint Error")]
+    #[error("Try From Endpoint Error")]
     TryFromEndpoint,
 
-    #[error("invalid address {0}")]
-    InvalidAddress(String),
+    #[error("Unsupported Endpoint {0}")]
+    UnsupportedEndpoint(String),
 
-    #[error("invalid path {0}")]
-    InvalidPath(String),
-
-    #[error("invalid endpoint {0}")]
-    InvalidEndpoint(String),
-
-    #[error("Encode error: {0}")]
-    Encode(String),
-
-    #[error("Decode error: {0}")]
-    Decode(String),
-
-    #[error("Parse endpoint error {0}")]
+    #[error("Parse Endpoint Error {0}")]
     ParseEndpoint(String),
-
-    #[error("Timeout Error")]
-    Timeout,
-
-    #[error("Channel Send Error: {0}")]
-    ChannelSend(String),
-
-    #[error(transparent)]
-    ChannelRecv(#[from] async_channel::RecvError),
 
     #[cfg(feature = "ws")]
     #[error("Ws Error: {0}")]
     WsError(#[from] async_tungstenite::tungstenite::Error),
-
-    #[cfg(feature = "tls")]
-    #[error("Tls Error: {0}")]
-    Rustls(#[from] karyon_async_rustls::rustls::Error),
 
     #[cfg(feature = "tls")]
     #[error("Invalid DNS Name: {0}")]
@@ -51,10 +26,4 @@ pub enum Error {
 
     #[error(transparent)]
     KaryonCore(#[from] karyon_core::Error),
-}
-
-impl<T> From<async_channel::SendError<T>> for Error {
-    fn from(error: async_channel::SendError<T>) -> Self {
-        Error::ChannelSend(error.to_string())
-    }
 }

--- a/net/src/listener.rs
+++ b/net/src/listener.rs
@@ -1,21 +1,25 @@
+use std::result::Result;
+
 use async_trait::async_trait;
 
-use crate::{Conn, Endpoint, Result};
+use crate::{Conn, Endpoint};
 
 /// Alias for `Box<dyn ConnListener>`
-pub type Listener<T> = Box<dyn ConnListener<Item = T>>;
+pub type Listener<C, E> = Box<dyn ConnListener<Message = C, Error = E>>;
 
 /// A trait for objects which can be converted to [`Listener`].
 pub trait ToListener {
-    type Item;
-    fn to_listener(self) -> Listener<Self::Item>;
+    type Message;
+    type Error;
+    fn to_listener(self) -> Listener<Self::Message, Self::Error>;
 }
 
 /// ConnListener is a generic network listener interface for
 /// [`tcp::TcpConn`], [`tls::TlsConn`], [`ws::WsConn`], and [`unix::UnixConn`].
 #[async_trait]
 pub trait ConnListener: Send + Sync {
-    type Item;
-    fn local_endpoint(&self) -> Result<Endpoint>;
-    async fn accept(&self) -> Result<Conn<Self::Item>>;
+    type Message;
+    type Error;
+    fn local_endpoint(&self) -> Result<Endpoint, Self::Error>;
+    async fn accept(&self) -> Result<Conn<Self::Message, Self::Error>, Self::Error>;
 }

--- a/net/src/stream/websocket.rs
+++ b/net/src/stream/websocket.rs
@@ -1,5 +1,7 @@
 use std::{
+    io::ErrorKind,
     pin::Pin,
+    result::Result,
     task::{Context, Poll},
 };
 
@@ -9,6 +11,8 @@ use futures_util::{
     Sink, SinkExt, Stream, StreamExt, TryStreamExt,
 };
 use pin_project_lite::pin_project;
+
+use async_tungstenite::tungstenite::Error;
 
 #[cfg(feature = "tokio")]
 type WebSocketStream<T> =
@@ -21,16 +25,16 @@ use karyon_core::async_runtime::net::TcpStream;
 #[cfg(feature = "tls")]
 use crate::async_rustls::TlsStream;
 
-use crate::{codec::WebSocketCodec, Error, Result};
+use crate::codec::WebSocketCodec;
 
 pub struct WsStream<C> {
     inner: InnerWSConn,
     codec: C,
 }
 
-impl<C> WsStream<C>
+impl<C, E> WsStream<C>
 where
-    C: WebSocketCodec + Clone,
+    C: WebSocketCodec<Error = E> + Clone,
 {
     pub fn new_ws(conn: WebSocketStream<TcpStream>, codec: C) -> Self {
         Self {
@@ -79,53 +83,55 @@ pin_project! {
     }
 }
 
-impl<C> ReadWsStream<C>
+impl<C, E> ReadWsStream<C>
 where
-    C: WebSocketCodec,
+    C: WebSocketCodec<Error = E>,
+    E: From<Error>,
 {
-    pub async fn recv(&mut self) -> Result<C::Item> {
+    pub async fn recv(&mut self) -> Result<C::Message, E> {
         match self.inner.next().await {
             Some(msg) => match self.codec.decode(&msg?)? {
                 Some(m) => Ok(m),
                 None => todo!(),
             },
-            None => Err(Error::IO(std::io::ErrorKind::ConnectionAborted.into())),
+            None => Err(Error::Io(std::io::Error::from(ErrorKind::ConnectionAborted)).into()),
         }
     }
 }
 
-impl<C> WriteWsStream<C>
+impl<C, E> WriteWsStream<C>
 where
-    C: WebSocketCodec,
+    C: WebSocketCodec<Error = E>,
+    E: From<Error>,
 {
-    pub async fn send(&mut self, msg: C::Item) -> Result<()> {
+    pub async fn send(&mut self, msg: C::Message) -> Result<(), E> {
         let ws_msg = self.codec.encode(&msg)?;
-        self.inner.send(ws_msg).await
+        Ok(self.inner.send(ws_msg).await?)
     }
 }
 
 impl<C> Sink<Message> for WriteWsStream<C> {
     type Error = Error;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_ready(cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Message) -> Result<()> {
+    fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
         self.project().inner.start_send(item)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_flush(cx)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_close(cx)
     }
 }
 
 impl<C> Stream for ReadWsStream<C> {
-    type Item = Result<Message>;
+    type Item = Result<Message, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.try_poll_next_unpin(cx)
@@ -141,48 +147,47 @@ enum InnerWSConn {
 impl Sink<Message> for InnerWSConn {
     type Error = Error;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match &mut *self {
-            InnerWSConn::Plain(s) => Pin::new(s).poll_ready(cx).map_err(Error::from),
+            InnerWSConn::Plain(s) => Pin::new(s).poll_ready(cx),
             #[cfg(feature = "tls")]
-            InnerWSConn::Tls(s) => Pin::new(s).poll_ready(cx).map_err(Error::from),
+            InnerWSConn::Tls(s) => Pin::new(s).poll_ready(cx),
         }
     }
 
-    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<()> {
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
         match &mut *self {
-            InnerWSConn::Plain(s) => Pin::new(s).start_send(item).map_err(Error::from),
+            InnerWSConn::Plain(s) => Pin::new(s).start_send(item),
             #[cfg(feature = "tls")]
-            InnerWSConn::Tls(s) => Pin::new(s).start_send(item).map_err(Error::from),
+            InnerWSConn::Tls(s) => Pin::new(s).start_send(item),
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match &mut *self {
-            InnerWSConn::Plain(s) => Pin::new(s).poll_flush(cx).map_err(Error::from),
+            InnerWSConn::Plain(s) => Pin::new(s).poll_flush(cx),
             #[cfg(feature = "tls")]
-            InnerWSConn::Tls(s) => Pin::new(s).poll_flush(cx).map_err(Error::from),
+            InnerWSConn::Tls(s) => Pin::new(s).poll_flush(cx),
         }
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match &mut *self {
-            InnerWSConn::Plain(s) => Pin::new(s).poll_close(cx).map_err(Error::from),
+            InnerWSConn::Plain(s) => Pin::new(s).poll_close(cx),
             #[cfg(feature = "tls")]
-            InnerWSConn::Tls(s) => Pin::new(s).poll_close(cx).map_err(Error::from),
+            InnerWSConn::Tls(s) => Pin::new(s).poll_close(cx),
         }
-        .map_err(Error::from)
     }
 }
 
 impl Stream for InnerWSConn {
-    type Item = Result<Message>;
+    type Item = Result<Message, Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match &mut *self {
-            InnerWSConn::Plain(s) => Pin::new(s).poll_next(cx).map_err(Error::from),
+            InnerWSConn::Plain(s) => Pin::new(s).poll_next(cx),
             #[cfg(feature = "tls")]
-            InnerWSConn::Tls(s) => Pin::new(s).poll_next(cx).map_err(Error::from),
+            InnerWSConn::Tls(s) => Pin::new(s).poll_next(cx),
         }
     }
 }

--- a/p2p/src/codec.rs
+++ b/p2p/src/codec.rs
@@ -1,11 +1,11 @@
 use karyon_core::util::{decode, encode, encode_into_slice};
 
-use karyon_net::{
-    codec::{Codec, Decoder, Encoder, LengthCodec},
-    Result,
-};
+use karyon_net::codec::{Codec, Decoder, Encoder, LengthCodec};
 
-use crate::message::{NetMsg, RefreshMsg};
+use crate::{
+    message::{NetMsg, RefreshMsg},
+    Error, Result,
+};
 
 #[derive(Clone)]
 pub struct NetMsgCodec {
@@ -21,23 +21,26 @@ impl NetMsgCodec {
 }
 
 impl Codec for NetMsgCodec {
-    type Item = NetMsg;
+    type Message = NetMsg;
+    type Error = Error;
 }
 
 impl Encoder for NetMsgCodec {
-    type EnItem = NetMsg;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = NetMsg;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         let src = encode(src)?;
-        self.inner_codec.encode(&src, dst)
+        Ok(self.inner_codec.encode(&src, dst)?)
     }
 }
 
 impl Decoder for NetMsgCodec {
-    type DeItem = NetMsg;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
+    type DeMessage = NetMsg;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
         match self.inner_codec.decode(src)? {
             Some((n, s)) => {
-                let (m, _) = decode::<Self::DeItem>(&s)?;
+                let (m, _) = decode::<Self::DeMessage>(&s)?;
                 Ok(Some((n, m)))
             }
             None => Ok(None),
@@ -49,21 +52,24 @@ impl Decoder for NetMsgCodec {
 pub struct RefreshMsgCodec {}
 
 impl Codec for RefreshMsgCodec {
-    type Item = RefreshMsg;
+    type Message = RefreshMsg;
+    type Error = Error;
 }
 
 impl Encoder for RefreshMsgCodec {
-    type EnItem = RefreshMsg;
-    fn encode(&self, src: &Self::EnItem, dst: &mut [u8]) -> Result<usize> {
+    type EnMessage = RefreshMsg;
+    type EnError = Error;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
         let n = encode_into_slice(src, dst)?;
         Ok(n)
     }
 }
 
 impl Decoder for RefreshMsgCodec {
-    type DeItem = RefreshMsg;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeItem)>> {
-        let (m, n) = decode::<Self::DeItem>(src)?;
+    type DeMessage = RefreshMsg;
+    type DeError = Error;
+    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
+        let (m, n) = decode::<Self::DeMessage>(src)?;
         Ok(Some((n, m)))
     }
 }

--- a/p2p/src/conn_queue.rs
+++ b/p2p/src/conn_queue.rs
@@ -1,9 +1,8 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use karyon_core::{async_runtime::lock::Mutex, async_util::CondVar};
-use karyon_net::Conn;
 
-use crate::{connection::ConnDirection, connection::Connection, message::NetMsg, Result};
+use crate::{connection::ConnDirection, connection::Connection, ConnRef, Result};
 
 /// Connection queue
 pub struct ConnQueue {
@@ -20,7 +19,7 @@ impl ConnQueue {
     }
 
     /// Handle a connection by pushing it into the queue and wait for the disconnect signal
-    pub async fn handle(&self, conn: Conn<NetMsg>, direction: ConnDirection) -> Result<()> {
+    pub async fn handle(&self, conn: ConnRef, direction: ConnDirection) -> Result<()> {
         let endpoint = conn.peer_endpoint()?;
 
         let (disconnect_tx, disconnect_rx) = async_channel::bounded(1);

--- a/p2p/src/connection.rs
+++ b/p2p/src/connection.rs
@@ -8,12 +8,12 @@ use karyon_core::{
     util::encode,
 };
 
-use karyon_net::{Conn, Endpoint};
+use karyon_net::Endpoint;
 
 use crate::{
     message::{NetMsg, NetMsgCmd, ProtocolMsg, ShutdownMsg},
     protocol::{Protocol, ProtocolEvent, ProtocolID},
-    Error, Result,
+    ConnRef, Error, Result,
 };
 
 /// Defines the direction of a network connection.
@@ -34,7 +34,7 @@ impl fmt::Display for ConnDirection {
 
 pub struct Connection {
     pub(crate) direction: ConnDirection,
-    conn: Conn<NetMsg>,
+    conn: ConnRef,
     disconnect_signal: Sender<Result<()>>,
     /// `EventEmitter` responsible for sending events to the registered protocols.
     protocol_events: Arc<EventEmitter<ProtocolID>>,
@@ -44,7 +44,7 @@ pub struct Connection {
 
 impl Connection {
     pub fn new(
-        conn: Conn<NetMsg>,
+        conn: ConnRef,
         signal: Sender<Result<()>>,
         direction: ConnDirection,
         remote_endpoint: Endpoint,

--- a/p2p/src/discovery/mod.rs
+++ b/p2p/src/discovery/mod.rs
@@ -12,7 +12,7 @@ use karyon_core::{
     crypto::KeyPair,
 };
 
-use karyon_net::{Conn, Endpoint};
+use karyon_net::Endpoint;
 
 use crate::{
     config::Config,
@@ -20,14 +20,13 @@ use crate::{
     connection::ConnDirection,
     connector::Connector,
     listener::Listener,
-    message::NetMsg,
     monitor::Monitor,
     routing_table::{
         RoutingTable, CONNECTED_ENTRY, DISCONNECTED_ENTRY, INCOMPATIBLE_ENTRY, PENDING_ENTRY,
         UNREACHABLE_ENTRY, UNSTABLE_ENTRY,
     },
     slots::ConnectionSlots,
-    Error, PeerID, Result,
+    ConnRef, Error, PeerID, Result,
 };
 
 use lookup::LookupService;
@@ -179,7 +178,7 @@ impl Discovery {
     async fn start_listener(self: &Arc<Self>, endpoint: &Endpoint) -> Result<Endpoint> {
         let callback = {
             let this = self.clone();
-            |c: Conn<NetMsg>| async move {
+            |c: ConnRef| async move {
                 this.conn_queue.handle(c, ConnDirection::Inbound).await?;
                 Ok(())
             }
@@ -218,7 +217,7 @@ impl Discovery {
             let this = self.clone();
             let endpoint = endpoint.clone();
             let pid = pid.clone();
-            |conn: Conn<NetMsg>| async move {
+            |conn: ConnRef| async move {
                 let result = this.conn_queue.handle(conn, ConnDirection::Outbound).await;
 
                 // If the entry is not in the routing table, ignore the result

--- a/p2p/src/discovery/refresh.rs
+++ b/p2p/src/discovery/refresh.rs
@@ -10,7 +10,7 @@ use karyon_core::{
     async_util::{sleep, timeout, Backoff, TaskGroup, TaskResult},
 };
 
-use karyon_net::{udp, Connection, Endpoint, Error as NetError};
+use karyon_net::{udp, Connection, Endpoint};
 
 use crate::{
     codec::RefreshMsgCodec,
@@ -184,7 +184,7 @@ impl RefreshService {
         while retry < self.config.refresh_connect_retries {
             match self.send_ping_msg(&conn, &endpoint).await {
                 Ok(()) => return Ok(()),
-                Err(Error::KaryonNet(NetError::Timeout)) => {
+                Err(Error::Timeout) => {
                     retry += 1;
                     backoff.sleep().await;
                 }
@@ -194,7 +194,7 @@ impl RefreshService {
             }
         }
 
-        Err(NetError::Timeout.into())
+        Err(Error::Timeout)
     }
 
     /// Set up a UDP listener and start listening for Ping messages from other

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -8,23 +8,26 @@ pub enum Error {
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
-    #[error("Unsupported protocol error: {0}")]
+    #[error("Unsupported Protocol Error: {0}")]
     UnsupportedProtocol(String),
 
     #[error("Unsupported Endpoint: {0}")]
     UnsupportedEndpoint(String),
 
-    #[error("PeerID try from PublicKey Error")]
+    #[error("PeerID Try From PublicKey Error")]
     PeerIDTryFromPublicKey,
 
-    #[error("PeerID try from String Error")]
+    #[error("PeerID Try From String Error")]
     PeerIDTryFromString,
 
-    #[error("Invalid message error: {0}")]
+    #[error("Invalid Message Error: {0}")]
     InvalidMsg(String),
 
     #[error("Incompatible Peer")]
     IncompatiblePeer,
+
+    #[error("Timeout Error")]
+    Timeout,
 
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
@@ -41,13 +44,13 @@ pub enum Error {
     #[error("Parse Error: {0}")]
     ParseError(String),
 
-    #[error("Incompatible version error: {0}")]
+    #[error("Incompatible Version Error: {0}")]
     IncompatibleVersion(String),
 
-    #[error("Config error: {0}")]
+    #[error("Config Error: {0}")]
     Config(String),
 
-    #[error("Peer shutdown")]
+    #[error("Peer Shutdown")]
     PeerShutdown,
 
     #[error("Invalid Pong Msg")]
@@ -59,7 +62,7 @@ pub enum Error {
     #[error("Lookup error: {0}")]
     Lookup(&'static str),
 
-    #[error("Peer already connected")]
+    #[error("Peer Already Connected")]
     PeerAlreadyConnected,
 
     #[error("Yasna Error: {0}")]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -76,3 +76,6 @@ pub mod keypair {
 }
 
 pub use error::{Error, Result};
+
+type ListenerRef = karyon_net::Listener<message::NetMsg, Error>;
+type ConnRef = karyon_net::Conn<message::NetMsg, Error>;

--- a/p2p/src/protocols/ping.rs
+++ b/p2p/src/protocols/ping.rs
@@ -12,13 +12,11 @@ use karyon_core::{
     util::decode,
 };
 
-use karyon_net::Error as NetError;
-
 use crate::{
     peer::Peer,
     protocol::{Protocol, ProtocolEvent, ProtocolID},
     version::Version,
-    Result,
+    Error, Result,
 };
 
 const MAX_FAILUERS: u32 = 3;
@@ -114,7 +112,7 @@ impl PingProtocol {
             retry = 0;
         }
 
-        Err(NetError::Timeout.into())
+        Err(Error::Timeout)
     }
 }
 


### PR DESCRIPTION
Add Error Type to Codec Trait and remove the redundant errors from
the net crate.

This will make it easier to implement a custom codec while providing a
custom error type when using the Codec API in `karyon_net` crate.

Add custom WebSocket Codec #11 

This includes breaking changes.

