### PR TITLE
Allow for customizable notification format

### DIFF
--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -14,7 +14,10 @@ use crate::{error::Error, net::TcpConfig};
 use crate::{
     codec::{ClonableJsonCodec, JsonCodec},
     error::Result,
+    message::Notification,
     net::ToEndpoint,
+    server::channel::NewNotification,
+    server::default_notification_encoder,
     server::PubSubRPCService,
     server::RPCService,
 };
@@ -152,6 +155,7 @@ where
                 tcp_config: Default::default(),
                 #[cfg(feature = "tls")]
                 tls_config: None,
+                notification_encoder: default_notification_encoder,
             },
             codec,
             executor: None,
@@ -321,6 +325,15 @@ where
     /// With an executor.
     pub async fn with_executor(mut self, ex: Executor) -> Self {
         self.executor = Some(ex);
+        self
+    }
+
+    /// With a custom notification encoder
+    pub fn with_notification_encoder(
+        mut self,
+        notification_encoder: fn(NewNotification) -> Notification,
+    ) -> Self {
+        self.config.notification_encoder = notification_encoder;
         self
     }
 

--- a/jsonrpc/src/server/channel.rs
+++ b/jsonrpc/src/server/channel.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub(crate) struct NewNotification {
+pub struct NewNotification {
     pub sub_id: SubscriptionID,
     pub result: serde_json::Value,
     pub method: String,


### PR DESCRIPTION
This makes it possible to implement a notification json message using the "by-position" format, where the "params" field is an array.

Since this is supported by the use of a new builder method and defaults to the existing behavior, this doesn't break the existing users.