### PR TITLE
Override the subscription ID at callsite

### DIFF
--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -60,7 +60,7 @@ impl HelloWorld {
 #[rpc_pubsub_impl]
 impl HelloWorld {
     async fn log_subscribe(&self, chan: Arc<Channel>, method: String, _params: Value) -> Result<Value, RPCError> {
-        let sub = chan.new_subscription(&method).await;
+        let sub = chan.new_subscription(&method, None).await.expect("Failed to subscribe");
         let sub_id = sub.id.clone();
         smol::spawn(async move {
             loop {

--- a/jsonrpc/examples/tokio_server/src/main.rs
+++ b/jsonrpc/examples/tokio_server/src/main.rs
@@ -52,7 +52,7 @@ impl Calc {
         method: String,
         _params: Value,
     ) -> Result<Value, RPCError> {
-        let sub = chan.new_subscription(&method).await;
+        let sub = chan.new_subscription(&method, None).await.expect("Failed to subscribe");
         let sub_id = sub.id;
         tokio::spawn(async move {
             loop {

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error("Subscription Closed")]
     SubscriptionClosed,
 
+    #[error("Subscription duplicated: {0}")]
+    SubscriptionDuplicated(String),
+
     #[error("ClientDisconnected")]
     ClientDisconnected,
 

--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -225,7 +225,7 @@ where
     ///         method: String,
     ///         _params: Value,
     ///     ) -> Result<Value, RPCError> {
-    ///         let sub = chan.new_subscription(&method).await;
+    ///         let sub = chan.new_subscription(&method, None).await.expect("Failed to subscribe");
     ///         let sub_id = sub.id.clone();
     ///         Ok(serde_json::json!(sub_id))
     ///     }


### PR DESCRIPTION
This makes it possible to have an externally managed subscription id.

This brings the question of the duplicated ID management which is now better handled by the Channel methods.

The example and tests have been updated accordingly.