### PR TITLE
BREAKING API CHANGE Prevent allocating memory based on the max buffer capacity

### DIFF
--- a/jsonrpc/examples/client.rs
+++ b/jsonrpc/examples/client.rs
@@ -18,7 +18,7 @@ struct Pong {}
 fn main() {
     env_logger::init();
     smol::future::block_on(async {
-        let client = ClientBuilder::new("tcp://127.0.0.1:6000")
+        let client = ClientBuilder::new("tcp://127.0.0.1:7878")
             .expect("Create client builder")
             .build()
             .await

--- a/jsonrpc/examples/server.rs
+++ b/jsonrpc/examples/server.rs
@@ -56,7 +56,7 @@ fn main() {
         };
 
         // Creates a new server
-        let server = ServerBuilder::new("tcp://127.0.0.1:6000")
+        let server = ServerBuilder::new("tcp://127.0.0.1:7878")
             .expect("Create a new server builder")
             .service(Arc::new(calc))
             .build()

--- a/jsonrpc/examples/server_custom_codec.rs
+++ b/jsonrpc/examples/server_custom_codec.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use karyon_jsonrpc::{
-    codec::{Codec, Decoder, Encoder},
+    codec::{ByteBuffer, Codec, Decoder, Encoder},
     error::{Error, RPCError},
     rpc_impl,
     server::ServerBuilder,
@@ -42,14 +42,14 @@ impl Encoder for CustomJsonCodec {
     fn encode(
         &self,
         src: &Self::EnMessage,
-        dst: &mut [u8],
+        dst: &mut ByteBuffer,
     ) -> std::result::Result<usize, Self::EnError> {
         let msg = match serde_json::to_string(src) {
             Ok(m) => m,
             Err(err) => return Err(Error::Encode(err.to_string())),
         };
         let buf = msg.as_bytes();
-        dst[..buf.len()].copy_from_slice(buf);
+        dst.extend_from_slice(buf);
         Ok(buf.len())
     }
 }
@@ -59,9 +59,9 @@ impl Decoder for CustomJsonCodec {
     type DeError = Error;
     fn decode(
         &self,
-        src: &mut [u8],
+        src: &mut ByteBuffer,
     ) -> std::result::Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
-        let de = serde_json::Deserializer::from_slice(src);
+        let de = serde_json::Deserializer::from_slice(src.as_ref());
         let mut iter = de.into_iter::<serde_json::Value>();
 
         let item = match iter.next() {

--- a/jsonrpc/src/client/builder.rs
+++ b/jsonrpc/src/client/builder.rs
@@ -64,7 +64,7 @@ where
     /// use serde_json::Value;
     ///
     /// use karyon_jsonrpc::{
-    ///     client::ClientBuilder, codec::{Codec, Decoder, Encoder},
+    ///     client::ClientBuilder, codec::{Codec, Decoder, Encoder, ByteBuffer},
     ///     error::{Error, Result}
     /// };
     ///
@@ -85,13 +85,13 @@ where
     /// impl Encoder for CustomJsonCodec {
     ///     type EnMessage = serde_json::Value;
     ///     type EnError = Error;
-    ///     fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
+    ///     fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
     ///         let msg = match serde_json::to_string(src) {
     ///             Ok(m) => m,
     ///             Err(err) => return Err(Error::Encode(err.to_string())),
     ///         };
     ///         let buf = msg.as_bytes();
-    ///         dst[..buf.len()].copy_from_slice(buf);
+    ///         dst.extend_from_slice(buf);
     ///         Ok(buf.len())
     ///     }
     /// }
@@ -99,8 +99,8 @@ where
     /// impl Decoder for CustomJsonCodec {
     ///     type DeMessage = serde_json::Value;
     ///     type DeError = Error;
-    ///     fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
-    ///         let de = serde_json::Deserializer::from_slice(src);
+    ///     fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+    ///         let de = serde_json::Deserializer::from_slice(src.as_ref());
     ///         let mut iter = de.into_iter::<serde_json::Value>();
     ///
     ///         let item = match iter.next() {

--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -49,7 +49,7 @@ where
     /// use serde_json::Value;
     /// #[cfg(feature = "ws")]
     /// use karyon_jsonrpc::codec::{WebSocketCodec, WebSocketDecoder, WebSocketEncoder};
-    /// use karyon_jsonrpc::{server::ServerBuilder, codec::{Codec, Decoder, Encoder, }, error::{Error, Result}};
+    /// use karyon_jsonrpc::{server::ServerBuilder, codec::{Codec, Decoder, Encoder, ByteBuffer}, error::{Error, Result}};
     ///
     ///
     /// #[derive(Clone)]
@@ -69,13 +69,13 @@ where
     /// impl Encoder for CustomJsonCodec {
     ///     type EnMessage = serde_json::Value;
     ///     type EnError = Error;
-    ///     fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
+    ///     fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
     ///         let msg = match serde_json::to_string(src) {
     ///             Ok(m) => m,
     ///             Err(err) => return Err(Error::Encode(err.to_string())),
     ///         };
     ///         let buf = msg.as_bytes();
-    ///         dst[..buf.len()].copy_from_slice(buf);
+    ///         dst.extend_from_slice(buf);
     ///         Ok(buf.len())
     ///     }
     /// }
@@ -83,8 +83,8 @@ where
     /// impl Decoder for CustomJsonCodec {
     ///     type DeMessage = serde_json::Value;
     ///     type DeError = Error;
-    ///     fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
-    ///         let de = serde_json::Deserializer::from_slice(src);
+    ///     fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+    ///         let de = serde_json::Deserializer::from_slice(src.as_ref());
     ///         let mut iter = de.into_iter::<serde_json::Value>();
     ///
     ///         let item = match iter.next() {

--- a/net/examples/tcp_codec.rs
+++ b/net/examples/tcp_codec.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use karyon_core::async_util::sleep;
 
 use karyon_net::{
-    codec::{Codec, Decoder, Encoder},
+    codec::{ByteBuffer, Codec, Decoder, Encoder},
     tcp, ConnListener, Connection, Endpoint, Error, Result,
 };
 
@@ -18,8 +18,8 @@ impl Codec for NewLineCodec {
 impl Encoder for NewLineCodec {
     type EnMessage = String;
     type EnError = Error;
-    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
-        dst[..src.len()].copy_from_slice(src.as_bytes());
+    fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
+        dst.extend_from_slice(src.as_bytes());
         Ok(src.len())
     }
 }
@@ -27,9 +27,12 @@ impl Encoder for NewLineCodec {
 impl Decoder for NewLineCodec {
     type DeMessage = String;
     type DeError = Error;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
-        match src.iter().position(|&b| b == b'\n') {
-            Some(i) => Ok(Some((i + 1, String::from_utf8(src[..i].to_vec()).unwrap()))),
+    fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+        match src.as_ref().iter().position(|&b| b == b'\n') {
+            Some(i) => Ok(Some((
+                i + 1,
+                String::from_utf8(src.as_ref()[..i].to_vec()).unwrap(),
+            ))),
             None => Ok(None),
         }
     }

--- a/net/src/codec/buffer.rs
+++ b/net/src/codec/buffer.rs
@@ -1,20 +1,17 @@
-pub type ByteBuffer = Buffer<Vec<u8>>;
+pub type ByteBuffer = Buffer;
 
 #[derive(Debug)]
-pub struct Buffer<B> {
-    inner: B,
+pub struct Buffer {
+    inner: Vec<u8>,
     len: usize,
     cap: usize,
 }
 
-impl<B> Buffer<B>
-where
-    B: AsMut<[u8]> + AsRef<[u8]>,
-{
-    /// Constructs a new, empty Buffer<B>.
-    pub fn new(b: B) -> Self {
+impl Buffer {
+    /// Constructs a new, empty Buffer.
+    pub fn new(b: Vec<u8>) -> Self {
         Self {
-            cap: b.as_ref().len(),
+            cap: b.len(),
             inner: b,
             len: 0,
         }
@@ -36,14 +33,14 @@ where
     pub fn extend_from_slice(&mut self, bytes: &[u8]) {
         let old_len = self.len;
         self.resize(self.len + bytes.len());
-        self.inner.as_mut()[old_len..bytes.len() + old_len].copy_from_slice(bytes);
+        self.inner[old_len..bytes.len() + old_len].copy_from_slice(bytes);
     }
 
     /// Shortens the buffer, dropping the first `cnt` bytes and keeping the
     /// rest.
     pub fn advance(&mut self, cnt: usize) {
         assert!(self.len >= cnt);
-        self.inner.as_mut().rotate_left(cnt);
+        self.inner.rotate_left(cnt);
         self.resize(self.len - cnt);
     }
 
@@ -53,21 +50,15 @@ where
     }
 }
 
-impl<B> AsMut<[u8]> for Buffer<B>
-where
-    B: AsMut<[u8]> + AsRef<[u8]>,
-{
+impl AsMut<[u8]> for Buffer {
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.inner.as_mut()[..self.len]
+        &mut self.inner[..self.len]
     }
 }
 
-impl<B> AsRef<[u8]> for Buffer<B>
-where
-    B: AsMut<[u8]> + AsRef<[u8]>,
-{
+impl AsRef<[u8]> for Buffer {
     fn as_ref(&self) -> &[u8] {
-        &self.inner.as_ref()[..self.len]
+        &self.inner[..self.len]
     }
 }
 
@@ -77,7 +68,7 @@ mod tests {
 
     #[test]
     fn test_buffer_advance() {
-        let mut buf = Buffer::new([0u8; 32]);
+        let mut buf = Buffer::new(vec![0u8; 32]);
         buf.extend_from_slice(&[1, 2, 3]);
         assert_eq!([1, 2, 3], buf.as_ref());
     }

--- a/net/src/codec/buffer.rs
+++ b/net/src/codec/buffer.rs
@@ -4,15 +4,15 @@ pub type ByteBuffer = Buffer;
 pub struct Buffer {
     inner: Vec<u8>,
     len: usize,
-    cap: usize,
+    max_length: usize,
 }
 
 impl Buffer {
     /// Constructs a new, empty Buffer.
-    pub fn new(b: Vec<u8>) -> Self {
+    pub fn new(max_length: usize) -> Self {
         Self {
-            cap: b.len(),
-            inner: b,
+            max_length,
+            inner: Vec::new(),
             len: 0,
         }
     }
@@ -25,21 +25,45 @@ impl Buffer {
 
     /// Resizes the buffer in-place so that `len` is equal to `new_size`.
     pub fn resize(&mut self, new_size: usize) {
-        assert!(self.cap > new_size);
+        // Check the Buffer doesn't grow beyond its max length.
+        assert!(
+            self.max_length > new_size,
+            "buffer resize to {} overflows the buffer max_length ({})",
+            new_size,
+            self.max_length
+        );
+        // Make sure the vector can contain the data.
+        // Note 1: reserve() is a no-op if the vector capacity is already large
+        // enough, but we don't want to cause the unsigned to underflow.
+        // Note 2: we don't shrink the vector memory if the length is reduced,
+        // as this operation might be costly and the released memory expected to
+        // be small.
+        // Note 3: the vector capacity (aka allocated memory) might be larger
+        // than max_length due to the allocator doing over-provisioning, but it
+        // is guaranteed that the data length won't overflow.
+        if new_size > self.len {
+            self.inner.reserve(new_size - self.len);
+        }
+        // This is a no-op if the new_size is greater or equal to self.len
+        self.inner.truncate(new_size);
         self.len = new_size;
     }
 
     /// Appends all elements in a slice to the buffer.
     pub fn extend_from_slice(&mut self, bytes: &[u8]) {
-        let old_len = self.len;
         self.resize(self.len + bytes.len());
-        self.inner[old_len..bytes.len() + old_len].copy_from_slice(bytes);
+        self.inner.extend_from_slice(bytes);
     }
 
     /// Shortens the buffer, dropping the first `cnt` bytes and keeping the
     /// rest.
     pub fn advance(&mut self, cnt: usize) {
-        assert!(self.len >= cnt);
+        assert!(
+            self.len >= cnt,
+            "buffer advance of {} underflows the buffer length ({})",
+            cnt,
+            self.len
+        );
         self.inner.rotate_left(cnt);
         self.resize(self.len - cnt);
     }
@@ -67,9 +91,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_buffer_advance() {
-        let mut buf = Buffer::new(vec![0u8; 32]);
-        buf.extend_from_slice(&[1, 2, 3]);
-        assert_eq!([1, 2, 3], buf.as_ref());
+    fn test_buffer() {
+        let mut buf = Buffer::new(32);
+        assert_eq!(&[] as &[u8], buf.as_ref());
+        assert_eq!(0, buf.len());
+        assert_eq!(true, buf.is_empty());
+
+        buf.extend_from_slice(&[1, 2, 3, 4, 5]);
+        assert_eq!(&[1, 2, 3, 4, 5], buf.as_ref());
+        assert_eq!(5, buf.len());
+        assert_eq!(false, buf.is_empty());
+
+        buf.advance(2);
+        assert_eq!(&[3, 4, 5], buf.as_ref());
+        assert_eq!(3, buf.len());
+        assert_eq!(false, buf.is_empty());
+
+        buf.extend_from_slice(&[6, 7, 8]);
+        assert_eq!(&[3, 4, 5, 6, 7, 8], buf.as_ref());
+        assert_eq!(6, buf.len());
+        assert_eq!(false, buf.is_empty());
+
+        buf.advance(4);
+        assert_eq!(&[7, 8], buf.as_ref());
+        assert_eq!(2, buf.len());
+        assert_eq!(false, buf.is_empty());
+
+        buf.advance(2);
+        assert_eq!(&[] as &[u8], buf.as_ref());
+        assert_eq!(0, buf.len());
+        assert_eq!(true, buf.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "buffer resize to 9 overflows the buffer max_length (8)")]
+    fn test_buffer_resize_overflow() {
+        let mut buf = Buffer::new(8);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    #[should_panic(expected = "buffer advance of 5 underflows the buffer length (4)")]
+    fn test_buffer_advance_underflow() {
+        let mut buf = Buffer::new(8);
+        buf.extend_from_slice(&[1, 2, 3, 4]);
+        buf.advance(5);
     }
 }

--- a/net/src/codec/buffer.rs
+++ b/net/src/codec/buffer.rs
@@ -1,3 +1,5 @@
+pub type ByteBuffer = Buffer<Vec<u8>>;
+
 #[derive(Debug)]
 pub struct Buffer<B> {
     inner: B,

--- a/net/src/codec/bytes_codec.rs
+++ b/net/src/codec/bytes_codec.rs
@@ -1,5 +1,5 @@
 use crate::{
-    codec::{Codec, Decoder, Encoder},
+    codec::{ByteBuffer, Codec, Decoder, Encoder},
     Error, Result,
 };
 
@@ -13,8 +13,8 @@ impl Codec for BytesCodec {
 impl Encoder for BytesCodec {
     type EnMessage = Vec<u8>;
     type EnError = Error;
-    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
-        dst[..src.len()].copy_from_slice(src);
+    fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
+        dst.extend_from_slice(src);
         Ok(src.len())
     }
 }
@@ -22,11 +22,11 @@ impl Encoder for BytesCodec {
 impl Decoder for BytesCodec {
     type DeMessage = Vec<u8>;
     type DeError = Error;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
+    fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
         if src.is_empty() {
             Ok(None)
         } else {
-            Ok(Some((src.len(), src.to_vec())))
+            Ok(Some((src.len(), src.as_ref().to_vec())))
         }
     }
 }

--- a/net/src/codec/length_codec.rs
+++ b/net/src/codec/length_codec.rs
@@ -1,7 +1,7 @@
 use karyon_core::util::{decode, encode_into_slice};
 
 use crate::{
-    codec::{Codec, Decoder, Encoder},
+    codec::{ByteBuffer, Codec, Decoder, Encoder},
     Error, Result,
 };
 
@@ -18,32 +18,37 @@ impl Codec for LengthCodec {
 impl Encoder for LengthCodec {
     type EnMessage = Vec<u8>;
     type EnError = Error;
-    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
+    fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
         let length_buf = &mut [0; MSG_LENGTH_SIZE];
         encode_into_slice(&(src.len() as u32), length_buf)?;
-        dst[..MSG_LENGTH_SIZE].copy_from_slice(length_buf);
-        dst[MSG_LENGTH_SIZE..src.len() + MSG_LENGTH_SIZE].copy_from_slice(src);
-        Ok(src.len() + MSG_LENGTH_SIZE)
+
+        dst.resize(MSG_LENGTH_SIZE);
+        dst.extend_from_slice(length_buf);
+
+        dst.resize(src.len());
+        dst.extend_from_slice(src);
+
+        Ok(dst.len())
     }
 }
 
 impl Decoder for LengthCodec {
     type DeMessage = Vec<u8>;
     type DeError = Error;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
+    fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
         if src.len() < MSG_LENGTH_SIZE {
             return Ok(None);
         }
 
         let mut length = [0; MSG_LENGTH_SIZE];
-        length.copy_from_slice(&src[..MSG_LENGTH_SIZE]);
+        length.copy_from_slice(&src.as_ref()[..MSG_LENGTH_SIZE]);
         let (length, _) = decode::<u32>(&length)?;
         let length = length as usize;
 
         if src.len() - MSG_LENGTH_SIZE >= length {
             Ok(Some((
                 length + MSG_LENGTH_SIZE,
-                src[MSG_LENGTH_SIZE..length + MSG_LENGTH_SIZE].to_vec(),
+                src.as_ref()[MSG_LENGTH_SIZE..length + MSG_LENGTH_SIZE].to_vec(),
             )))
         } else {
             Ok(None)

--- a/net/src/codec/mod.rs
+++ b/net/src/codec/mod.rs
@@ -1,8 +1,10 @@
+mod buffer;
 mod bytes_codec;
 mod length_codec;
 #[cfg(feature = "ws")]
 mod websocket;
 
+pub use buffer::{Buffer, ByteBuffer};
 pub use bytes_codec::BytesCodec;
 pub use length_codec::LengthCodec;
 
@@ -26,7 +28,7 @@ pub trait Encoder {
     fn encode(
         &self,
         src: &Self::EnMessage,
-        dst: &mut [u8],
+        dst: &mut ByteBuffer,
     ) -> std::result::Result<usize, Self::EnError>;
 }
 
@@ -35,6 +37,6 @@ pub trait Decoder {
     type DeError: From<std::io::Error>;
     fn decode(
         &self,
-        src: &mut [u8],
+        src: &mut ByteBuffer,
     ) -> std::result::Result<Option<(usize, Self::DeMessage)>, Self::DeError>;
 }

--- a/net/src/stream/mod.rs
+++ b/net/src/stream/mod.rs
@@ -40,7 +40,7 @@ where
         Self {
             inner,
             decoder,
-            buffer: Buffer::new(vec![0u8; BUFFER_SIZE]),
+            buffer: Buffer::new(BUFFER_SIZE),
         }
     }
 
@@ -72,7 +72,7 @@ where
             inner,
             encoder,
             high_water_mark: 131072,
-            buffer: Buffer::new(vec![0u8; BUFFER_SIZE]),
+            buffer: Buffer::new(BUFFER_SIZE),
         }
     }
 }

--- a/net/src/stream/mod.rs
+++ b/net/src/stream/mod.rs
@@ -1,4 +1,3 @@
-mod buffer;
 #[cfg(feature = "ws")]
 mod websocket;
 
@@ -21,17 +20,15 @@ use pin_project_lite::pin_project;
 
 use karyon_core::async_runtime::io::{AsyncRead, AsyncWrite};
 
-use crate::codec::{Decoder, Encoder};
+use crate::codec::{Buffer, ByteBuffer, Decoder, Encoder};
 
-use buffer::Buffer;
-
-const BUFFER_SIZE: usize = 2048 * 2048; // 4MB
+const BUFFER_SIZE: usize = 4096 * 4096; // 16MB
 const INITIAL_BUFFER_SIZE: usize = 1024 * 1024; // 1MB
 
 pub struct ReadStream<T, C> {
     inner: T,
     decoder: C,
-    buffer: Buffer<Vec<u8>>,
+    buffer: ByteBuffer,
 }
 
 impl<T, C> ReadStream<T, C>
@@ -61,7 +58,7 @@ pin_project! {
         inner: T,
         encoder: C,
         high_water_mark: usize,
-        buffer: Buffer<Vec<u8>>,
+        buffer: ByteBuffer,
     }
 }
 
@@ -90,7 +87,7 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
 
-        if let Some((n, item)) = this.decoder.decode(this.buffer.as_mut())? {
+        if let Some((n, item)) = this.decoder.decode(&mut this.buffer)? {
             this.buffer.advance(n);
             return Poll::Ready(Some(Ok(item)));
         }
@@ -117,7 +114,7 @@ where
             #[cfg(feature = "tokio")]
             buf.clear();
 
-            match this.decoder.decode(this.buffer.as_mut())? {
+            match this.decoder.decode(&mut this.buffer)? {
                 Some((cn, item)) => {
                     this.buffer.advance(cn);
                     return Poll::Ready(Some(Ok(item)));
@@ -167,9 +164,7 @@ where
 
     fn start_send(mut self: Pin<&mut Self>, item: C::EnMessage) -> Result<(), Self::Error> {
         let this = &mut *self;
-        let mut buf = [0u8; INITIAL_BUFFER_SIZE];
-        let n = this.encoder.encode(&item, &mut buf)?;
-        this.buffer.extend_from_slice(&buf[..n]);
+        this.encoder.encode(&item, &mut this.buffer)?;
         Ok(())
     }
 

--- a/net/src/transports/udp.rs
+++ b/net/src/transports/udp.rs
@@ -55,7 +55,7 @@ where
     }
 
     async fn recv(&self) -> std::result::Result<Self::Message, Self::Error> {
-        let mut buf = Buffer::new(vec![0; BUFFER_SIZE]);
+        let mut buf = Buffer::new(BUFFER_SIZE);
         let (_, addr) = self.inner.recv_from(buf.as_mut()).await?;
         match self.codec.decode(&mut buf)? {
             Some((_, msg)) => Ok((msg, Endpoint::new_udp_addr(addr))),
@@ -65,7 +65,7 @@ where
 
     async fn send(&self, msg: Self::Message) -> std::result::Result<(), Self::Error> {
         let (msg, out_addr) = msg;
-        let mut buf = Buffer::new(vec![0; BUFFER_SIZE]);
+        let mut buf = Buffer::new(BUFFER_SIZE);
         self.codec.encode(&msg, &mut buf)?;
         let addr: SocketAddr = out_addr
             .try_into()

--- a/net/src/transports/udp.rs
+++ b/net/src/transports/udp.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use karyon_core::async_runtime::net::UdpSocket;
 
 use crate::{
-    codec::Codec,
+    codec::{Buffer, Codec},
     connection::{Conn, Connection, ToConn},
     endpoint::Endpoint,
     Result,
@@ -55,8 +55,8 @@ where
     }
 
     async fn recv(&self) -> std::result::Result<Self::Message, Self::Error> {
-        let mut buf = [0u8; BUFFER_SIZE];
-        let (_, addr) = self.inner.recv_from(&mut buf).await?;
+        let mut buf = Buffer::new(vec![0; BUFFER_SIZE]);
+        let (_, addr) = self.inner.recv_from(buf.as_mut()).await?;
         match self.codec.decode(&mut buf)? {
             Some((_, msg)) => Ok((msg, Endpoint::new_udp_addr(addr))),
             None => Err(std::io::Error::from(std::io::ErrorKind::ConnectionAborted).into()),
@@ -65,12 +65,12 @@ where
 
     async fn send(&self, msg: Self::Message) -> std::result::Result<(), Self::Error> {
         let (msg, out_addr) = msg;
-        let mut buf = [0u8; BUFFER_SIZE];
+        let mut buf = Buffer::new(vec![0; BUFFER_SIZE]);
         self.codec.encode(&msg, &mut buf)?;
         let addr: SocketAddr = out_addr
             .try_into()
             .map_err(|_| std::io::Error::other("Convert Endpoint to SocketAddress"))?;
-        self.inner.send_to(&buf, addr).await?;
+        self.inner.send_to(buf.as_ref(), addr).await?;
         Ok(())
     }
 }

--- a/p2p/src/codec.rs
+++ b/p2p/src/codec.rs
@@ -1,6 +1,6 @@
 use karyon_core::util::{decode, encode, encode_into_slice};
 
-use karyon_net::codec::{Codec, Decoder, Encoder, LengthCodec};
+use karyon_net::codec::{ByteBuffer, Codec, Decoder, Encoder, LengthCodec};
 
 use crate::{
     message::{NetMsg, RefreshMsg},
@@ -28,7 +28,7 @@ impl Codec for NetMsgCodec {
 impl Encoder for NetMsgCodec {
     type EnMessage = NetMsg;
     type EnError = Error;
-    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
+    fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
         let src = encode(src)?;
         Ok(self.inner_codec.encode(&src, dst)?)
     }
@@ -37,7 +37,7 @@ impl Encoder for NetMsgCodec {
 impl Decoder for NetMsgCodec {
     type DeMessage = NetMsg;
     type DeError = Error;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
+    fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
         match self.inner_codec.decode(src)? {
             Some((n, s)) => {
                 let (m, _) = decode::<Self::DeMessage>(&s)?;
@@ -59,8 +59,8 @@ impl Codec for RefreshMsgCodec {
 impl Encoder for RefreshMsgCodec {
     type EnMessage = RefreshMsg;
     type EnError = Error;
-    fn encode(&self, src: &Self::EnMessage, dst: &mut [u8]) -> Result<usize> {
-        let n = encode_into_slice(src, dst)?;
+    fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
+        let n = encode_into_slice(src, dst.as_mut())?;
         Ok(n)
     }
 }
@@ -68,8 +68,8 @@ impl Encoder for RefreshMsgCodec {
 impl Decoder for RefreshMsgCodec {
     type DeMessage = RefreshMsg;
     type DeError = Error;
-    fn decode(&self, src: &mut [u8]) -> Result<Option<(usize, Self::DeMessage)>> {
-        let (m, n) = decode::<Self::DeMessage>(src)?;
+    fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+        let (m, n) = decode::<Self::DeMessage>(src.as_ref())?;
         Ok(Some((n, m)))
     }
 }


### PR DESCRIPTION
This reduces the scope of Buffer and make it only allocated the memory it needs instead of preallocating for the maximum length, reducing the memory consumption.