### PR TITLE
Use bytes crate as the internal implementation for Buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,7 @@ dependencies = [
  "async-trait",
  "async-tungstenite",
  "bincode",
+ "bytes",
  "futures-util",
  "karyon_async_rustls",
  "karyon_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ futures-util = { version = "0.3", default-features = false }
 
 # encode
 bincode = "2.0"
+bytes = "1.10"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.22"

--- a/core/src/util/decode.rs
+++ b/core/src/util/decode.rs
@@ -5,6 +5,9 @@ use crate::Result;
 /// Decodes a given type `T` from the given slice. returns the decoded value
 /// along with the number of bytes read.
 pub fn decode<T: Decode<()>>(src: &[u8]) -> Result<(T, usize)> {
-    let (result, bytes_read) = bincode::decode_from_slice(src, bincode::config::standard())?;
+    let (result, bytes_read) = bincode::decode_from_slice::<T, _>(
+        src,
+        bincode::config::standard().with_fixed_int_encoding(),
+    )?;
     Ok((result, bytes_read))
 }

--- a/core/src/util/encode.rs
+++ b/core/src/util/encode.rs
@@ -4,11 +4,16 @@ use crate::{Error, Result};
 
 /// Encode the given type `T` into a `Vec<u8>`.
 pub fn encode<T: Encode>(src: &T) -> Result<Vec<u8>> {
-    let vec = bincode::encode_to_vec(src, bincode::config::standard())?;
+    let vec = bincode::encode_to_vec(src, bincode::config::standard().with_fixed_int_encoding())?;
     Ok(vec)
 }
 
 /// Encode the given type `T` into the given slice..
 pub fn encode_into_slice<T: Encode>(src: &T, dst: &mut [u8]) -> Result<usize> {
-    bincode::encode_into_slice(src, dst, bincode::config::standard()).map_err(Error::from)
+    bincode::encode_into_slice(
+        src,
+        dst,
+        bincode::config::standard().with_fixed_int_encoding(),
+    )
+    .map_err(Error::from)
 }

--- a/jsonrpc/examples/server.rs
+++ b/jsonrpc/examples/server.rs
@@ -56,7 +56,7 @@ fn main() {
         };
 
         // Creates a new server
-        let server = ServerBuilder::new("tcp://127.0.0.1:7878")
+        let server = ServerBuilder::new("tcp://127.0.0.1:6000")
             .expect("Create a new server builder")
             .service(Arc::new(calc))
             .build()

--- a/jsonrpc/examples/tokio_server/src/main.rs
+++ b/jsonrpc/examples/tokio_server/src/main.rs
@@ -90,7 +90,7 @@ async fn main() {
     });
 
     // Creates a new server
-    let server = ServerBuilder::new("ws://127.0.0.1:6000")
+    let server = ServerBuilder::new("tcp://127.0.0.1:6000")
         .expect("Create a new server builder")
         .service(calc.clone())
         .pubsub_service(calc)

--- a/jsonrpc/src/client/builder.rs
+++ b/jsonrpc/src/client/builder.rs
@@ -41,7 +41,7 @@ impl ClientBuilder<JsonCodec> {
     /// };
     /// ```
     pub fn new(endpoint: impl ToEndpoint) -> Result<ClientBuilder<JsonCodec>> {
-        ClientBuilder::new_with_codec(endpoint, JsonCodec {})
+        ClientBuilder::new_with_codec(endpoint, JsonCodec::default())
     }
 }
 

--- a/jsonrpc/src/codec.rs
+++ b/jsonrpc/src/codec.rs
@@ -67,8 +67,12 @@ impl Encoder for JsonCodec {
         };
         let buf = msg.as_bytes();
 
-        if buf.len() >= self.max_size {
-            return Err(Error::InvalidMsg("Msg too large".to_string()));
+        if buf.len() > self.max_size {
+            return Err(Error::BufferFull(format!(
+                "Buffer size {} exceeds maximum {}",
+                buf.len(),
+                self.max_size
+            )));
         }
 
         dst.extend_from_slice(buf);
@@ -83,8 +87,12 @@ impl Decoder for JsonCodec {
         &self,
         src: &mut ByteBuffer,
     ) -> Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
-        if src.len() >= self.max_size {
-            return Err(Error::InvalidMsg("Msg too large".to_string()));
+        if src.len() > self.max_size {
+            return Err(Error::BufferFull(format!(
+                "Buffer size {} exceeds maximum {}",
+                src.len(),
+                self.max_size
+            )));
         }
 
         let de = serde_json::Deserializer::from_slice(src.as_ref());

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[error("Invalid Message Error: {0}")]
     InvalidMsg(String),
 
+    #[error("Buffer Full: {0}")]
+    BufferFull(String),
+
     #[error(transparent)]
     ParseJSON(#[from] serde_json::Error),
 

--- a/jsonrpc/src/server/builder.rs
+++ b/jsonrpc/src/server/builder.rs
@@ -361,6 +361,6 @@ impl ServerBuilder<JsonCodec> {
     /// };
     /// ```
     pub fn new(endpoint: impl ToEndpoint) -> Result<ServerBuilder<JsonCodec>> {
-        Self::new_with_codec(endpoint, JsonCodec {})
+        Self::new_with_codec(endpoint, JsonCodec::default())
     }
 }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -41,6 +41,7 @@ thiserror = { workspace = true }
 url = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 bincode = { workspace = true, features = ["derive"] }
+bytes = { workspace = true }
 
 # async
 async-trait = { workspace = true }

--- a/net/src/codec/buffer.rs
+++ b/net/src/codec/buffer.rs
@@ -1,88 +1,56 @@
+use bytes::{Buf, BytesMut};
+
 pub type ByteBuffer = Buffer;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Buffer {
-    inner: Vec<u8>,
-    len: usize,
-    max_length: usize,
+    inner: BytesMut,
 }
 
 impl Buffer {
     /// Constructs a new, empty Buffer.
-    pub fn new(max_length: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            max_length,
-            inner: Vec::new(),
-            len: 0,
+            inner: BytesMut::new(),
         }
     }
 
     /// Returns the number of elements in the buffer.
-    #[allow(dead_code)]
     pub fn len(&self) -> usize {
-        self.len
+        self.inner.len()
     }
 
     /// Resizes the buffer in-place so that `len` is equal to `new_size`.
     pub fn resize(&mut self, new_size: usize) {
-        // Check the Buffer doesn't grow beyond its max length.
-        assert!(
-            self.max_length > new_size,
-            "buffer resize to {} overflows the buffer max_length ({})",
-            new_size,
-            self.max_length
-        );
-        // Make sure the vector can contain the data.
-        // Note 1: reserve() is a no-op if the vector capacity is already large
-        // enough, but we don't want to cause the unsigned to underflow.
-        // Note 2: we don't shrink the vector memory if the length is reduced,
-        // as this operation might be costly and the released memory expected to
-        // be small.
-        // Note 3: the vector capacity (aka allocated memory) might be larger
-        // than max_length due to the allocator doing over-provisioning, but it
-        // is guaranteed that the data length won't overflow.
-        if new_size > self.len {
-            self.inner.reserve(new_size - self.len);
-        }
-        // This is a no-op if the new_size is greater or equal to self.len
-        self.inner.truncate(new_size);
-        self.len = new_size;
+        self.inner.resize(new_size, 0u8);
     }
 
     /// Appends all elements in a slice to the buffer.
     pub fn extend_from_slice(&mut self, bytes: &[u8]) {
-        self.resize(self.len + bytes.len());
         self.inner.extend_from_slice(bytes);
     }
 
     /// Shortens the buffer, dropping the first `cnt` bytes and keeping the
     /// rest.
     pub fn advance(&mut self, cnt: usize) {
-        assert!(
-            self.len >= cnt,
-            "buffer advance of {} underflows the buffer length ({})",
-            cnt,
-            self.len
-        );
-        self.inner.rotate_left(cnt);
-        self.resize(self.len - cnt);
+        self.inner.advance(cnt);
     }
 
     /// Returns `true` if the buffer contains no elements.
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.inner.is_empty()
     }
 }
 
 impl AsMut<[u8]> for Buffer {
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.inner[..self.len]
+        self.inner.as_mut()
     }
 }
 
 impl AsRef<[u8]> for Buffer {
     fn as_ref(&self) -> &[u8] {
-        &self.inner[..self.len]
+        self.inner.as_ref()
     }
 }
 
@@ -92,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_buffer() {
-        let mut buf = Buffer::new(32);
+        let mut buf = Buffer::new();
         assert_eq!(&[] as &[u8], buf.as_ref());
         assert_eq!(0, buf.len());
         assert!(buf.is_empty());
@@ -121,20 +89,5 @@ mod tests {
         assert_eq!(&[] as &[u8], buf.as_ref());
         assert_eq!(0, buf.len());
         assert!(buf.is_empty());
-    }
-
-    #[test]
-    #[should_panic(expected = "buffer resize to 9 overflows the buffer max_length (8)")]
-    fn test_buffer_resize_overflow() {
-        let mut buf = Buffer::new(8);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    }
-
-    #[test]
-    #[should_panic(expected = "buffer advance of 5 underflows the buffer length (4)")]
-    fn test_buffer_advance_underflow() {
-        let mut buf = Buffer::new(8);
-        buf.extend_from_slice(&[1, 2, 3, 4]);
-        buf.advance(5);
     }
 }

--- a/net/src/codec/bytes_codec.rs
+++ b/net/src/codec/bytes_codec.rs
@@ -33,8 +33,12 @@ impl Encoder for BytesCodec {
     type EnMessage = Vec<u8>;
     type EnError = Error;
     fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
-        if src.len() >= self.max_size {
-            return Err(Error::MsgTooLarge);
+        if src.len() > self.max_size {
+            return Err(Error::BufferFull(format!(
+                "Buffer size {} exceeds maximum {}",
+                src.len(),
+                self.max_size
+            )));
         }
 
         dst.extend_from_slice(src);
@@ -46,8 +50,12 @@ impl Decoder for BytesCodec {
     type DeMessage = Vec<u8>;
     type DeError = Error;
     fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
-        if src.len() >= self.max_size {
-            return Err(Error::MsgTooLarge);
+        if src.len() > self.max_size {
+            return Err(Error::BufferFull(format!(
+                "Buffer size {} exceeds maximum {}",
+                src.len(),
+                self.max_size
+            )));
         }
 
         if src.is_empty() {

--- a/net/src/codec/bytes_codec.rs
+++ b/net/src/codec/bytes_codec.rs
@@ -18,6 +18,12 @@ impl Default for BytesCodec {
     }
 }
 
+impl BytesCodec {
+    pub fn new(max_size: usize) -> Self {
+        Self { max_size }
+    }
+}
+
 impl Codec for BytesCodec {
     type Message = Vec<u8>;
     type Error = Error;

--- a/net/src/codec/bytes_codec.rs
+++ b/net/src/codec/bytes_codec.rs
@@ -3,8 +3,21 @@ use crate::{
     Error, Result,
 };
 
+const MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4MB
+
 #[derive(Clone)]
-pub struct BytesCodec {}
+pub struct BytesCodec {
+    max_size: usize,
+}
+
+impl Default for BytesCodec {
+    fn default() -> Self {
+        Self {
+            max_size: MAX_BUFFER_SIZE,
+        }
+    }
+}
+
 impl Codec for BytesCodec {
     type Message = Vec<u8>;
     type Error = Error;
@@ -14,6 +27,10 @@ impl Encoder for BytesCodec {
     type EnMessage = Vec<u8>;
     type EnError = Error;
     fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
+        if src.len() >= self.max_size {
+            return Err(Error::MsgTooLarge);
+        }
+
         dst.extend_from_slice(src);
         Ok(src.len())
     }
@@ -23,6 +40,10 @@ impl Decoder for BytesCodec {
     type DeMessage = Vec<u8>;
     type DeError = Error;
     fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+        if src.len() >= self.max_size {
+            return Err(Error::MsgTooLarge);
+        }
+
         if src.is_empty() {
             Ok(None)
         } else {

--- a/net/src/codec/length_codec.rs
+++ b/net/src/codec/length_codec.rs
@@ -5,11 +5,24 @@ use crate::{
     Error, Result,
 };
 
+const MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4MB
+
 /// The size of the message length.
 const MSG_LENGTH_SIZE: usize = std::mem::size_of::<u32>();
 
 #[derive(Clone)]
-pub struct LengthCodec {}
+pub struct LengthCodec {
+    max_size: usize,
+}
+
+impl Default for LengthCodec {
+    fn default() -> Self {
+        Self {
+            max_size: MAX_BUFFER_SIZE,
+        }
+    }
+}
+
 impl Codec for LengthCodec {
     type Message = Vec<u8>;
     type Error = Error;
@@ -19,13 +32,13 @@ impl Encoder for LengthCodec {
     type EnMessage = Vec<u8>;
     type EnError = Error;
     fn encode(&self, src: &Self::EnMessage, dst: &mut ByteBuffer) -> Result<usize> {
+        if src.len() >= self.max_size {
+            return Err(Error::MsgTooLarge);
+        }
+
         let length_buf = &mut [0; MSG_LENGTH_SIZE];
         encode_into_slice(&(src.len() as u32), length_buf)?;
-
-        dst.resize(MSG_LENGTH_SIZE);
         dst.extend_from_slice(length_buf);
-
-        dst.resize(src.len());
         dst.extend_from_slice(src);
 
         Ok(dst.len())
@@ -36,6 +49,10 @@ impl Decoder for LengthCodec {
     type DeMessage = Vec<u8>;
     type DeError = Error;
     fn decode(&self, src: &mut ByteBuffer) -> Result<Option<(usize, Self::DeMessage)>> {
+        if src.len() >= self.max_size {
+            return Err(Error::MsgTooLarge);
+        }
+
         if src.len() < MSG_LENGTH_SIZE {
             return Ok(None);
         }

--- a/net/src/error.rs
+++ b/net/src/error.rs
@@ -10,21 +10,21 @@ pub enum Error {
     #[error("Try From Endpoint Error")]
     TryFromEndpoint,
 
-    #[error("Unsupported Endpoint {0}")]
+    #[error("Unsupported Endpoint Error:{0}")]
     UnsupportedEndpoint(String),
 
-    #[error("Parse Endpoint Error {0}")]
+    #[error("Parse Endpoint Error: {0}")]
     ParseEndpoint(String),
 
-    #[error("Msg too large")]
-    MsgTooLarge,
+    #[error("Buffer Full Error: {0}")]
+    BufferFull(String),
 
     #[cfg(feature = "ws")]
     #[error("Ws Error: {0}")]
     WsError(#[from] Box<async_tungstenite::tungstenite::Error>),
 
     #[cfg(feature = "tls")]
-    #[error("Invalid DNS Name: {0}")]
+    #[error("Invalid DNS Name Error: {0}")]
     InvalidDnsNameError(#[from] rustls_pki_types::InvalidDnsNameError),
 
     #[error(transparent)]

--- a/net/src/error.rs
+++ b/net/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     #[error("Parse Endpoint Error {0}")]
     ParseEndpoint(String),
 
+    #[error("Msg too large")]
+    MsgTooLarge,
+
     #[cfg(feature = "ws")]
     #[error("Ws Error: {0}")]
     WsError(#[from] Box<async_tungstenite::tungstenite::Error>),

--- a/net/src/stream/mod.rs
+++ b/net/src/stream/mod.rs
@@ -144,11 +144,7 @@ where
             let n = ready!(Pin::new(&mut this.inner).poll_write(cx, this.buffer.as_ref()))?;
 
             if n == 0 {
-                return Poll::Ready(Err(std::io::Error::new(
-                    ErrorKind::UnexpectedEof,
-                    "End of file",
-                )
-                .into()));
+                return Poll::Ready(Err(std::io::Error::from(ErrorKind::UnexpectedEof).into()));
             }
 
             this.buffer.advance(n);

--- a/net/src/transports/udp.rs
+++ b/net/src/transports/udp.rs
@@ -10,8 +10,6 @@ use crate::{
     Result,
 };
 
-const BUFFER_SIZE: usize = 64 * 1024;
-
 /// UDP configuration
 #[derive(Default)]
 pub struct UdpConfig {}
@@ -55,7 +53,7 @@ where
     }
 
     async fn recv(&self) -> std::result::Result<Self::Message, Self::Error> {
-        let mut buf = Buffer::new(BUFFER_SIZE);
+        let mut buf = Buffer::new();
         let (_, addr) = self.inner.recv_from(buf.as_mut()).await?;
         match self.codec.decode(&mut buf)? {
             Some((_, msg)) => Ok((msg, Endpoint::new_udp_addr(addr))),
@@ -65,7 +63,7 @@ where
 
     async fn send(&self, msg: Self::Message) -> std::result::Result<(), Self::Error> {
         let (msg, out_addr) = msg;
-        let mut buf = Buffer::new(BUFFER_SIZE);
+        let mut buf = Buffer::new();
         self.codec.encode(&msg, &mut buf)?;
         let addr: SocketAddr = out_addr
             .try_into()

--- a/net/tests/codec_test.rs
+++ b/net/tests/codec_test.rs
@@ -1,0 +1,252 @@
+use karyon_net::{
+    codec::{Codec, Decoder, Encoder},
+    tcp::{dial, listen, TcpConfig},
+    ConnListener, Connection, Endpoint,
+};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+const DEFAULT_MAX_SIZE: usize = 8 * 1024 * 1024; // 8MB
+
+#[derive(Clone)]
+pub struct LinesCodec {
+    max_size: usize,
+}
+
+impl Default for LinesCodec {
+    fn default() -> Self {
+        Self {
+            max_size: DEFAULT_MAX_SIZE,
+        }
+    }
+}
+
+impl Codec for LinesCodec {
+    type Error = karyon_net::Error;
+    type Message = String;
+}
+
+impl Encoder for LinesCodec {
+    type EnError = karyon_net::Error;
+    type EnMessage = String;
+    fn encode(
+        &self,
+        src: &Self::EnMessage,
+        dst: &mut karyon_net::codec::ByteBuffer,
+    ) -> std::result::Result<usize, Self::EnError> {
+        if dst.len() >= self.max_size {
+            return Err(karyon_net::Error::IO(std::io::ErrorKind::Other.into()));
+        }
+
+        let mut src = src.as_bytes().to_vec();
+        src.push(b'\n');
+        dst.extend_from_slice(&src);
+        Ok(src.len())
+    }
+}
+
+impl Decoder for LinesCodec {
+    type DeError = karyon_net::Error;
+    type DeMessage = String;
+    fn decode(
+        &self,
+        src: &mut karyon_net::codec::ByteBuffer,
+    ) -> std::result::Result<Option<(usize, Self::DeMessage)>, Self::DeError> {
+        if src.len() >= self.max_size {
+            return Err(karyon_net::Error::IO(std::io::ErrorKind::Other.into()));
+        }
+
+        if src.is_empty() {
+            Ok(None)
+        } else {
+            let msg_bytes: Vec<u8> = src.as_ref().to_vec();
+            let newline_offset = match msg_bytes.iter().position(|b| *b == b'\n') {
+                Some(o) => o,
+                None => return Ok(None),
+            };
+            let msg = String::from_utf8_lossy(&msg_bytes[..newline_offset]).to_string();
+            Ok(Some((newline_offset + 1, msg)))
+        }
+    }
+}
+
+#[test]
+fn test_codec_tcp_basic() {
+    smol::block_on(async move {
+        let endpoint = Endpoint::from_str("tcp://127.0.0.1:6001").unwrap();
+        let config = TcpConfig::default();
+        let codec = LinesCodec::default();
+        let listener = listen(&endpoint, config.clone(), codec.clone())
+            .await
+            .unwrap();
+
+        let task = smol::spawn(async move {
+            loop {
+                let c = listener.accept().await.unwrap();
+                let _ = c.recv().await.unwrap();
+            }
+        });
+
+        // Give server time to start
+        smol::Timer::after(std::time::Duration::from_millis(500)).await;
+
+        let conn = dial(&endpoint, config, codec).await.unwrap();
+        conn.send("hello".to_string()).await.unwrap();
+        let _ = task.cancel().await;
+    });
+}
+
+#[test]
+fn test_codec_tcp_aggressive_messaging() {
+    smol::block_on(async move {
+        let endpoint = Endpoint::from_str("tcp://127.0.0.1:6002").unwrap();
+        let config = TcpConfig::default();
+        let codec = LinesCodec::default();
+        let listener = listen(&endpoint, config.clone(), codec.clone())
+            .await
+            .unwrap();
+
+        let received_count = Arc::new(AtomicUsize::new(0));
+        let received_count_clone = received_count.clone();
+
+        let server_task = smol::spawn(async move {
+            loop {
+                let conn = listener.accept().await.unwrap();
+                let count = received_count_clone.clone();
+
+                smol::spawn(async move {
+                    loop {
+                        match conn.recv().await {
+                            Ok(_) => {
+                                count.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                })
+                .detach();
+            }
+        });
+
+        // Give server time to start
+        smol::Timer::after(std::time::Duration::from_millis(500)).await;
+
+        // Create multiple concurrent connections
+        let mut client_tasks = Vec::new();
+        let num_connections = 5;
+        let messages_per_connection = 100;
+
+        for conn_id in 0..num_connections {
+            let endpoint = endpoint.clone();
+            let config = config.clone();
+            let codec = codec.clone();
+
+            let client_task = smol::spawn(async move {
+                let conn = dial(&endpoint, config, codec).await.unwrap();
+
+                // Send messages rapidly
+                for msg_id in 0..messages_per_connection {
+                    let message = format!("conn-{}-msg-{}", conn_id, msg_id);
+                    conn.send(message).await.unwrap();
+
+                    // Minimal delay to create aggressive timing
+                    if msg_id % 10 == 0 {
+                        smol::Timer::after(std::time::Duration::from_millis(1)).await;
+                    }
+                }
+            });
+
+            client_tasks.push(client_task);
+        }
+
+        // Wait for all clients to finish sending
+        for task in client_tasks {
+            task.await;
+        }
+
+        // Give some time for all messages to be processed
+        smol::Timer::after(std::time::Duration::from_secs(2)).await;
+
+        let total_expected = num_connections * (messages_per_connection);
+        let total_received = received_count.load(Ordering::Relaxed);
+
+        assert_eq!(
+            total_received, total_expected,
+            "Not all messages were received"
+        );
+
+        server_task.cancel().await;
+    });
+}
+
+#[test]
+fn test_codec_tcp_max_payload_size() {
+    smol::block_on(async move {
+        let endpoint = Endpoint::from_str("tcp://127.0.0.1:6003").unwrap();
+        let config = TcpConfig::default();
+        let codec = LinesCodec::default();
+        let listener = listen(&endpoint, config.clone(), codec.clone())
+            .await
+            .unwrap();
+
+        let server_task = smol::spawn(async move {
+            let conn = listener.accept().await.unwrap();
+
+            loop {
+                match conn.recv().await {
+                    Ok(msg) => {
+                        conn.send(msg).await.unwrap();
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        // Give server time to start
+        smol::Timer::after(std::time::Duration::from_millis(500)).await;
+
+        let conn = dial(&endpoint, config, codec).await.unwrap();
+
+        // Test different payload sizes
+        let test_sizes = vec![
+            (1024, true),              // 1KB
+            (64 * 1024, true),         // 64KB
+            (1024 * 1024, true),       // 1MB
+            (4 * 1024 * 1024, true),   // 4MB
+            (16 * 1024 * 1024, false), // 16MB
+        ];
+
+        for (size, pass) in &test_sizes {
+            println!("Testing payload size: {} bytes", size);
+
+            let msg = "a".repeat(*size);
+
+            // Send the payload
+            match conn.send(msg.clone()).await {
+                Ok(_) => {
+                    assert!(pass);
+                }
+                Err(_) => {
+                    assert!(!pass);
+                    continue;
+                }
+            }
+
+            // Wait for confirmation
+            let response = conn.recv().await.unwrap();
+
+            assert_eq!(
+                response.len(),
+                msg.len(),
+                "Server didn't confirm reception of {} message",
+                size
+            );
+
+            // Small delay between large messages
+            smol::Timer::after(std::time::Duration::from_millis(500)).await;
+        }
+
+        server_task.cancel().await.unwrap();
+    });
+}

--- a/p2p/src/codec.rs
+++ b/p2p/src/codec.rs
@@ -15,7 +15,7 @@ pub struct NetMsgCodec {
 impl NetMsgCodec {
     pub fn new() -> Self {
         Self {
-            inner_codec: LengthCodec {},
+            inner_codec: LengthCodec::default(),
         }
     }
 }


### PR DESCRIPTION
Previously, we used Vec<u8> as the inner type for Buffer, but it was inefficient. Additionally, we were asserting the payload size within Buffer instead of within the codec implementation.

This commit also adds proper tests for the codec.