### PR TITLE
feat(p2p): add access control policy for peer connections

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -3,7 +3,7 @@ SMOL_ALL  = smol,$(ALL_FEATURES)
 TOKIO_ALL = tokio,$(ALL_FEATURES)
 
 .PHONY: check fmt clippy unit-test integration-test test \
-	test-tcp test-tls test-quic test-multi-transport \
+	test-tcp test-tls test-quic test-multi-transport test-access-control \
 	test-smol test-tokio
 
 check:
@@ -36,6 +36,10 @@ test-quic:
 test-multi-transport:
 	cargo test --no-default-features --features $(SMOL_ALL) --test multi_transport
 	cargo test --no-default-features --features $(TOKIO_ALL) --test multi_transport
+
+test-access-control:
+	cargo test --no-default-features --features $(SMOL_ALL) --test access_control
+	cargo test --no-default-features --features $(TOKIO_ALL) --test access_control
 
 test-smol:
 	cargo test --no-default-features --features $(SMOL_ALL) --tests

--- a/p2p/src/access_control.rs
+++ b/p2p/src/access_control.rs
@@ -1,0 +1,53 @@
+use karyon_net::Endpoint;
+
+use crate::{peer::ConnDirection, protocol::ProtocolID, PeerID};
+
+/// A peer that has completed the handshake but has not joined the pool yet.
+pub struct PeerCandidate<'a> {
+    pub peer_id: &'a PeerID,
+    pub remote_endpoint: &'a Endpoint,
+    /// Protocols supported by both sides.
+    pub negotiated_protocols: &'a [ProtocolID],
+}
+
+/// The party being evaluated.
+pub enum Subject<'a> {
+    /// Before the handshake. Only the transport address is known.
+    Endpoint(&'a Endpoint),
+    /// After the handshake. The peer identity is known.
+    Peer(&'a PeerCandidate<'a>),
+}
+
+/// The purpose of the connection.
+#[derive(Clone, Debug)]
+pub enum Action {
+    /// A peer connection.
+    Connect(ConnDirection),
+    /// A discovery lookup query.
+    Lookup(ConnDirection),
+    /// A liveness check. No data is exchanged.
+    Probe(ConnDirection),
+}
+
+/// Policy that decides which peers this node talks to, and for what.
+///
+/// Synchronous by design: it runs on the accept loop, so a blocking
+/// policy would stall every other inbound connection. Keep its state
+/// in memory.
+pub trait AccessControl: Send + Sync {
+    /// Returns false to drop the connection.
+    ///
+    /// A `Subject::Endpoint` is evaluated before the handshake, when
+    /// only the address is known. A `Subject::Peer` is evaluated after
+    /// the handshake, when the identity is available.
+    fn allow(&self, subject: &Subject, action: Action) -> bool;
+}
+
+/// Default policy. Allows everything.
+pub struct AllowAll;
+
+impl AccessControl for AllowAll {
+    fn allow(&self, _subject: &Subject, _action: Action) -> bool {
+        true
+    }
+}

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -1,6 +1,11 @@
+use std::sync::Arc;
+
 use karyon_net::Endpoint;
 
-use crate::Version;
+use crate::{
+    access_control::{AccessControl, AllowAll},
+    Version,
+};
 
 /// Configuration for the p2p network.
 ///
@@ -35,6 +40,9 @@ pub struct Config {
 
     /// Enable monitor
     pub enable_monitor: bool,
+
+    /// Policy deciding who this node talks to. Defaults to `AllowAll`.
+    pub access_control: Arc<dyn AccessControl>,
 
     /////////////////
     // PeerPool
@@ -131,6 +139,7 @@ impl Default for Config {
             version: "0.1.0".parse().unwrap(),
 
             enable_monitor: false,
+            access_control: Arc::new(AllowAll),
 
             handshake_timeout: 4,
             ping_interval: 20,

--- a/p2p/src/discovery/kademlia/lookup.rs
+++ b/p2p/src/discovery/kademlia/lookup.rs
@@ -9,6 +9,7 @@ use karyon_core::{async_runtime::Executor, async_util::timeout, crypto::KeyPair}
 use karyon_net::Endpoint;
 
 use crate::{
+    access_control::{Action, Subject},
     bloom::BloomRef,
     connector::Connector,
     discovery::kademlia::{
@@ -21,6 +22,7 @@ use crate::{
     listener::Listener,
     message::{pick_endpoint, PeerAddr, Protocol, ShutdownMsg},
     monitor::{ConnectionKind, DiscoveryKind, Monitor},
+    peer::ConnDirection,
     slots::ConnectionSlots,
     util::decode,
     version::version_match,
@@ -98,6 +100,7 @@ impl LookupService {
             inbound_slots.clone(),
             monitor.clone(),
             config.handshake_timeout,
+            config.access_control.clone(),
             ex.clone(),
         );
 
@@ -261,6 +264,13 @@ impl LookupService {
         peer_id: Option<PeerID>,
         target_peer_id: &PeerID,
     ) -> Result<Vec<PeerMsg>> {
+        if !self.config.access_control.allow(
+            &Subject::Endpoint(&endpoint),
+            Action::Lookup(ConnDirection::Outbound),
+        ) {
+            return Err(Error::AccessDenied);
+        }
+
         let conn = self.connector.connect(&endpoint, &peer_id).await?;
         let result = self.handle_outbound(conn, target_peer_id).await;
 

--- a/p2p/src/discovery/kademlia/refresh.rs
+++ b/p2p/src/discovery/kademlia/refresh.rs
@@ -16,12 +16,14 @@ use karyon_core::{
 use karyon_net::{udp, Endpoint};
 
 use crate::{
+    access_control::{Action, Subject},
     discovery::kademlia::{
         messages::RefreshMsg,
         routing_table::{BucketEntry, Entry, RoutingTable, PENDING_ENTRY, UNREACHABLE_ENTRY},
     },
     message::{pick_endpoint, Protocol},
     monitor::{ConnectionKind, DiscoveryKind, Monitor},
+    peer::ConnDirection,
     util::{decode, encode},
     Config, Error, Result,
 };
@@ -217,6 +219,14 @@ impl RefreshService {
         let supported = [Protocol::Udp];
         let endpoint = pick_endpoint(&entry.discovery_addrs, &supported)
             .ok_or(Error::Lookup("No UDP discovery address available".into()))?;
+
+        if !self.config.access_control.allow(
+            &Subject::Endpoint(&endpoint),
+            Action::Probe(ConnDirection::Outbound),
+        ) {
+            return Err(Error::AccessDenied);
+        }
+
         let conn = udp::dial(&endpoint, Default::default()).await?;
         let peer_addr = SocketAddr::try_from(endpoint.clone())?;
         let backoff = Backoff::new(100, 5000);
@@ -293,6 +303,15 @@ impl RefreshService {
         }
 
         let sender_ep = Endpoint::new_udp_addr(sender);
+
+        if !self.config.access_control.allow(
+            &Subject::Endpoint(&sender_ep),
+            Action::Probe(ConnDirection::Inbound),
+        ) {
+            trace!("Drop refresh ping from denied source {sender_ip}");
+            return Ok(());
+        }
+
         self.monitor
             .notify(ConnectionKind::Accepted(sender_ep.clone()))
             .await;

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
     #[error("Peer Already Connected")]
     PeerAlreadyConnected,
 
+    #[error("Access Denied")]
+    AccessDenied,
+
     #[error("Peer Not Found: {0}")]
     PeerNotFound(String),
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+mod access_control;
 mod bloom;
 mod codec;
 mod config;
@@ -28,12 +29,13 @@ pub mod monitor;
 /// [`Read More`](./protocol/trait.Protocol.html)
 pub mod protocol;
 
+pub use access_control::{AccessControl, Action, AllowAll, PeerCandidate, Subject};
 pub use bloom::{Bloom, BloomRef};
 pub use config::Config;
 pub use discovery::{kademlia::KademliaDiscovery, DiscoveredPeer, Discovery};
 pub use message::{PeerAddr, Protocol};
 pub use node::Node;
-pub use peer::{Peer, PeerID};
+pub use peer::{ConnDirection, Peer, PeerID};
 pub use peer_pool::{PeerEvent, PeerPool};
 pub use version::Version;
 

--- a/p2p/src/listener.rs
+++ b/p2p/src/listener.rs
@@ -16,6 +16,7 @@ use karyon_net::{
 };
 
 use crate::{
+    access_control::{AccessControl, Action, Subject},
     codec::PeerNetMsgCodec,
     conn_queue::ConnQueue,
     monitor::{ConnectionKind, Monitor},
@@ -84,6 +85,7 @@ pub struct Listener<C: Codec<ByteBuffer> + Default + Clone> {
     conn_queue: Option<Arc<ConnQueue>>,
     monitor: Arc<Monitor>,
     handshake_timeout: Duration,
+    access_control: Arc<dyn AccessControl>,
     _codec: PhantomData<C>,
 }
 
@@ -98,6 +100,7 @@ where
         connection_slots: Arc<ConnectionSlots>,
         monitor: Arc<Monitor>,
         handshake_timeout: u64,
+        access_control: Arc<dyn AccessControl>,
         ex: Executor,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -107,6 +110,7 @@ where
             task_group: TaskGroup::with_executor(ex),
             monitor,
             handshake_timeout: Duration::from_secs(handshake_timeout),
+            access_control,
             _codec: PhantomData,
         })
     }
@@ -203,6 +207,15 @@ where
                 }
             };
 
+            // Callback mode is the kademlia lookup plane.
+            if !self.access_control.allow(
+                &Subject::Endpoint(&endpoint),
+                Action::Lookup(ConnDirection::Inbound),
+            ) {
+                debug!("Rejected inbound lookup connection from {endpoint}");
+                continue;
+            }
+
             self.monitor
                 .notify(ConnectionKind::Accepted(endpoint.clone()))
                 .await;
@@ -270,6 +283,7 @@ impl Listener<PeerNetMsgCodec> {
         conn_queue: Arc<ConnQueue>,
         monitor: Arc<Monitor>,
         handshake_timeout: u64,
+        access_control: Arc<dyn AccessControl>,
         ex: Executor,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -279,6 +293,7 @@ impl Listener<PeerNetMsgCodec> {
             task_group: TaskGroup::with_executor(ex),
             monitor,
             handshake_timeout: Duration::from_secs(handshake_timeout),
+            access_control,
             _codec: PhantomData,
         })
     }
@@ -344,6 +359,14 @@ impl Listener<PeerNetMsgCodec> {
                     continue;
                 }
             };
+
+            if !self.access_control.allow(
+                &Subject::Endpoint(&endpoint),
+                Action::Connect(ConnDirection::Inbound),
+            ) {
+                debug!("Rejected inbound connection from {endpoint}");
+                continue;
+            }
 
             self.monitor
                 .notify(ConnectionKind::Accepted(endpoint.clone()))
@@ -435,6 +458,14 @@ impl Listener<PeerNetMsgCodec> {
             };
 
             let peer_ep = incoming.peer_endpoint();
+
+            if !self.access_control.allow(
+                &Subject::Endpoint(&peer_ep),
+                Action::Connect(ConnDirection::Inbound),
+            ) {
+                debug!("Rejected inbound QUIC connection from {peer_ep}");
+                continue;
+            }
 
             self.monitor
                 .notify(ConnectionKind::Accepted(peer_ep.clone()))

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -15,6 +15,7 @@ use karyon_eventemitter::EventListener;
 use karyon_net::Endpoint;
 
 use crate::{
+    access_control::{Action, Subject},
     bloom::{Bloom, BloomRef},
     codec::PeerNetMsgCodec,
     config::Config,
@@ -24,6 +25,7 @@ use crate::{
     listener::Listener,
     message::{pick_endpoint, Protocol},
     monitor::{Monitor, PoolEvent},
+    peer::ConnDirection,
     peer_pool::{PeerEvent, PeerEventTopic, PeerPool},
     protocol::{PeerConn, Protocol as ProtocolTrait, ProtocolID, ProtocolKind},
     protocols::PingProtocol,
@@ -136,6 +138,7 @@ impl Node {
             conn_queue,
             monitor.clone(),
             config.handshake_timeout,
+            config.access_control.clone(),
             ex.clone(),
         );
 
@@ -199,6 +202,7 @@ impl Node {
             conn_queue,
             monitor.clone(),
             config.handshake_timeout,
+            config.access_control.clone(),
             ex.clone(),
         );
 
@@ -288,6 +292,14 @@ impl Node {
                 Some(ep) => ep,
                 None => continue,
             };
+
+            if !self.config.access_control.allow(
+                &Subject::Endpoint(&endpoint),
+                Action::Connect(ConnDirection::Outbound),
+            ) {
+                debug!("Skipped dialing denied endpoint {endpoint}");
+                continue;
+            }
 
             let peer_id = discovered.peer_id.clone();
 

--- a/p2p/src/peer_pool.rs
+++ b/p2p/src/peer_pool.rs
@@ -15,11 +15,12 @@ use karyon_eventemitter::{EventEmitter, EventListener, EventTopic, EventValue};
 use karyon_net::Endpoint;
 
 use crate::{
+    access_control::{Action, PeerCandidate, Subject},
     config::Config,
     conn_queue::{ConnQueue, QueuedConn},
     handshake::{handshake, HandshakeParams},
     monitor::{Monitor, PoolEvent},
-    peer::Peer,
+    peer::{ConnDirection, Peer},
     protocol::{Protocol, ProtocolConstructor, ProtocolID, ProtocolMeta},
     Error, PeerID, Result,
 };
@@ -236,7 +237,7 @@ impl PeerPool {
 
             let params = HandshakeParams {
                 own_id: &self.id,
-                is_inbound: matches!(queued.direction, crate::peer::ConnDirection::Inbound),
+                is_inbound: matches!(queued.direction, ConnDirection::Inbound),
                 config_version: &self.config.version,
                 protocols: &meta,
                 timeout_secs: self.config.handshake_timeout,
@@ -259,6 +260,34 @@ impl PeerPool {
                     continue;
                 }
             };
+
+            // Admission gate. Runs before the Peer is built, so a denied
+            // peer never gets tasks spawned or QUIC streams opened.
+            let candidate = PeerCandidate {
+                peer_id: &pid,
+                remote_endpoint: &queued.remote_endpoint,
+                negotiated_protocols: &negotiated,
+            };
+            let allowed = self.config.access_control.allow(
+                &Subject::Peer(&candidate),
+                Action::Connect(queued.direction.clone()),
+            );
+
+            if !allowed {
+                warn!("Access denied for peer {pid}");
+                self.monitor
+                    .notify(PoolEvent::HandshakeFailed(Some(pid.clone())))
+                    .await;
+                let _ = self
+                    .peer_emitter
+                    .emit(&PeerEvent::HandshakeFailed(Some(pid)))
+                    .await;
+                let _ = queued
+                    .disconnect_signal
+                    .send(Err(Error::AccessDenied))
+                    .await;
+                continue;
+            }
 
             if let Err(err) = self.new_peer(queued, pid, negotiated).await {
                 error!("new_peer failed: {err}");

--- a/p2p/tests/access_control.rs
+++ b/p2p/tests/access_control.rs
@@ -1,0 +1,199 @@
+mod shared;
+
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use karyon_core::{async_util::sleep, testing::run_test_with_executor};
+
+use karyon_p2p::{
+    monitor::PeerPoolEvent, AccessControl, Action, Config, ConnDirection, PeerID, Subject,
+};
+
+use shared::{create_node, fast_config, free_port};
+
+/// Policy based on peer ids: an allow list, a deny list, or both.
+///
+/// Deny takes precedence. An empty allow list accepts any peer that is
+/// not denied; a non-empty one denies any peer that is not allowed.
+#[derive(Default)]
+struct PeerIdList {
+    allowed: HashSet<PeerID>,
+    denied: HashSet<PeerID>,
+}
+
+impl PeerIdList {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn allow(mut self, id: PeerID) -> Self {
+        self.allowed.insert(id);
+        self
+    }
+
+    fn deny(mut self, id: PeerID) -> Self {
+        self.denied.insert(id);
+        self
+    }
+}
+
+impl AccessControl for PeerIdList {
+    fn allow(&self, subject: &Subject, _action: Action) -> bool {
+        let peer = match subject {
+            // An id list cannot evaluate a bare address.
+            Subject::Endpoint(_) => return true,
+            Subject::Peer(p) => p,
+        };
+
+        if self.denied.contains(peer.peer_id) {
+            return false;
+        }
+        self.allowed.is_empty() || self.allowed.contains(peer.peer_id)
+    }
+}
+
+/// Denies every inbound endpoint and counts how many times it was asked.
+struct DenyInbound {
+    calls: Arc<AtomicUsize>,
+}
+
+impl AccessControl for DenyInbound {
+    fn allow(&self, subject: &Subject, action: Action) -> bool {
+        match (subject, action) {
+            (Subject::Endpoint(_), Action::Connect(ConnDirection::Inbound)) => {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                false
+            }
+            _ => true,
+        }
+    }
+}
+
+#[test]
+fn denied_peer_never_joins_pool() {
+    run_test_with_executor(30, |ex| async move {
+        let listen_port = free_port();
+
+        // Built first so its id can go on node_a's deny list.
+        let node_b = create_node(
+            Config {
+                peer_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+
+        let banned = node_b.peer_id().clone();
+
+        let node_a = create_node(
+            Config {
+                listen_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                access_control: Arc::new(PeerIdList::new().deny(banned)),
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+
+        let pool_a = node_a.monitor().register::<PeerPoolEvent>();
+        node_a.run().await.expect("node_a run");
+        node_b.run().await.expect("node_b run");
+
+        // The handshake succeeds, then the admission gate drops it.
+        loop {
+            let ev = pool_a.recv().await.unwrap();
+            assert_ne!(ev.event, "NewPeer", "denied peer joined the pool");
+            if ev.event == "HandshakeFailed" {
+                break;
+            }
+        }
+
+        assert_eq!(node_a.peers().await, 0);
+
+        node_b.shutdown().await;
+        node_a.shutdown().await;
+    });
+}
+
+#[test]
+fn allowed_peer_joins_pool() {
+    run_test_with_executor(30, |ex| async move {
+        let listen_port = free_port();
+
+        let node_b = create_node(
+            Config {
+                peer_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+
+        let allowed = node_b.peer_id().clone();
+
+        let node_a = create_node(
+            Config {
+                listen_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                access_control: Arc::new(PeerIdList::new().allow(allowed)),
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+
+        let pool_a = node_a.monitor().register::<PeerPoolEvent>();
+        node_a.run().await.expect("node_a run");
+        node_b.run().await.expect("node_b run");
+
+        let ev = pool_a.recv().await.unwrap();
+        assert_eq!(ev.event, "NewPeer");
+        assert_eq!(node_a.peers().await, 1);
+
+        node_b.shutdown().await;
+        node_a.shutdown().await;
+    });
+}
+
+#[test]
+fn denied_endpoint_rejected_before_handshake() {
+    run_test_with_executor(30, |ex| async move {
+        let listen_port = free_port();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let node_a = create_node(
+            Config {
+                listen_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                access_control: Arc::new(DenyInbound {
+                    calls: calls.clone(),
+                }),
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+
+        node_a.run().await.expect("node_a run");
+
+        let node_b = create_node(
+            Config {
+                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                ..fast_config()
+            },
+            ex.clone(),
+        );
+        node_b.run().await.expect("node_b run");
+
+        // Wait for the gate to see at least one inbound connection.
+        while calls.load(Ordering::SeqCst) == 0 {
+            sleep(Duration::from_millis(50)).await;
+        }
+
+        // Dropped on the accept loop, so no peer is ever queued.
+        assert_eq!(node_a.peers().await, 0);
+
+        node_b.shutdown().await;
+        node_a.shutdown().await;
+    });
+}


### PR DESCRIPTION
New `AccessControl` trait: 

`allow(&Subject, Action) -> bool`, false drops the  connection. 

`Config::access_control` defaults to `AllowAll`. 
