### PR TITLE
refactor(p2p): naming cleanup

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -2,12 +2,15 @@ ALL_FEATURES = quic
 SMOL_ALL  = smol,$(ALL_FEATURES)
 TOKIO_ALL = tokio,$(ALL_FEATURES)
 
-.PHONY: check fmt clippy unit-test integration-test test \
+.PHONY: check check-examples fmt clippy unit-test integration-test test \
 	test-tcp test-tls test-quic test-multi-transport test-access-control \
 	test-smol test-tokio
 
 check:
 	cargo check
+
+check-examples:
+	cargo check --examples
 
 fmt:
 	cargo fmt --check

--- a/p2p/examples/chat.rs
+++ b/p2p/examples/chat.rs
@@ -29,9 +29,9 @@ struct Cli {
     #[arg(short)]
     bootstrap_peers: Vec<Endpoint>,
 
-    /// Optional list of peer endpoints for manual connections.
-    #[arg(short)]
-    peer_endpoints: Vec<Endpoint>,
+    /// Optional list of peers to dial directly.
+    #[arg(short = 'p')]
+    dial_peers: Vec<Endpoint>,
 
     /// Endpoints for accepting incoming connections.
     #[arg(short)]
@@ -111,7 +111,7 @@ fn main() {
     let config = Config {
         listen_endpoints: cli.listen_endpoints,
         discovery_endpoints: cli.discovery_endpoints,
-        peer_endpoints: cli.peer_endpoints,
+        dial_peers: cli.dial_peers,
         bootstrap_peers: cli.bootstrap_peers,
         ..Default::default()
     };

--- a/p2p/examples/peer.rs
+++ b/p2p/examples/peer.rs
@@ -17,9 +17,9 @@ struct Cli {
     #[arg(short)]
     bootstrap_peers: Vec<Endpoint>,
 
-    /// Optional list of peer endpoints for manual connections.
-    #[arg(short)]
-    peer_endpoints: Vec<Endpoint>,
+    /// Optional list of peers to dial directly.
+    #[arg(short = 'p')]
+    dial_peers: Vec<Endpoint>,
 
     /// Endpoints for accepting incoming connections (e.g. tcp://0.0.0.0:8000).
     #[arg(short)]
@@ -40,7 +40,7 @@ fn main() {
     let config = Config {
         listen_endpoints: cli.listen_endpoints,
         discovery_endpoints: cli.discovery_endpoints,
-        peer_endpoints: cli.peer_endpoints,
+        dial_peers: cli.dial_peers,
         bootstrap_peers: cli.bootstrap_peers,
         ..Default::default()
     };

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Configuration for the p2p network.
 ///
-/// `peer_endpoints` are static peers dialed directly (use for fixed
+/// `dial_peers` are static peers dialed directly (use for fixed
 /// topologies). `bootstrap_peers` are seeds for the default Kademlia
 /// discovery; the DHT grows the connection set from there. Custom
 /// `Discovery` implementations may interpret `bootstrap_peers`
@@ -86,13 +86,13 @@ pub struct Config {
     ///
     /// Either provide both (one of each kind) or leave the vector empty
     /// to disable Kademlia-style DHT discovery and rely on
-    /// `peer_endpoints` + `bootstrap_peers` for static peering.
+    /// `dial_peers` + `bootstrap_peers` for static peering.
     ///
     /// e.g. [tcp://0.0.0.0:7000, udp://0.0.0.0:7000]
     pub discovery_endpoints: Vec<Endpoint>,
     /// A list of endpoints representing peers that the `Discovery` will
     /// manually connect to.
-    pub peer_endpoints: Vec<Endpoint>,
+    pub dial_peers: Vec<Endpoint>,
     /// The number of available inbound slots for incoming connections.
     pub inbound_slots: usize,
     /// The number of available outbound slots for outgoing connections.
@@ -148,7 +148,7 @@ impl Default for Config {
             bootstrap_peers: vec![],
             listen_endpoints: vec![],
             discovery_endpoints: vec![],
-            peer_endpoints: vec![],
+            dial_peers: vec![],
             inbound_slots: 12,
             outbound_slots: 12,
             max_connect_retries: 3,

--- a/p2p/src/discovery/kademlia/mod.rs
+++ b/p2p/src/discovery/kademlia/mod.rs
@@ -54,7 +54,7 @@ pub struct KademliaDiscovery {
     refresh_service: Arc<RefreshService>,
 
     /// Discovered peers queued for the Node to dial. Producers
-    /// (connect_loop, manual peer_endpoints) push; the Node's
+    /// (connect_loop, manual dial_peers) push; the Node's
     /// connect_discovered_peers task drains via `recv()`.
     peer_queue: Arc<AsyncQueue<DiscoveredPeer>>,
 
@@ -205,8 +205,8 @@ impl Discovery for KademliaDiscovery {
         // Start the refresh service
         self.refresh_service.start().await?;
 
-        // Send manual peer endpoints as DiscoveredPeer
-        for endpoint in self.config.peer_endpoints.iter() {
+        // Send manual dial peers as DiscoveredPeer
+        for endpoint in self.config.dial_peers.iter() {
             if let Some(addr) = PeerAddr::from_endpoint(endpoint, 0) {
                 let peer = DiscoveredPeer {
                     peer_id: None,

--- a/p2p/src/discovery/mod.rs
+++ b/p2p/src/discovery/mod.rs
@@ -22,7 +22,7 @@ pub enum PeerConnectionEvent {
     /// Previously-connected peer has disconnected.
     Disconnected(PeerID),
     /// Connection attempt failed. Peer id may be unknown for
-    /// manual peer endpoints whose id wasn't pre-shared.
+    /// manual dial peers whose id wasn't pre-shared.
     ConnectFailed(Option<PeerID>),
 }
 

--- a/p2p/src/peer/connection.rs
+++ b/p2p/src/peer/connection.rs
@@ -14,15 +14,14 @@ use karyon_core::async_runtime::io::{AsyncReadExt, AsyncWriteExt};
 use karyon_net::{framed, quic::QuicConn, StreamMux};
 
 #[cfg(feature = "quic")]
-use crate::message::StreamInit;
+use crate::{message::StreamInit, peer::ConnDirection, util::encode};
 
 use crate::{
     codec::PeerNetMsgCodec,
     conn_queue::QueuedConn,
     message::{PeerNetCmd, PeerNetMsg, ProtocolMsg, ShutdownMsg},
-    peer::ConnDirection,
     protocol::{ProtocolEvent, ProtocolID},
-    util::{decode, encode},
+    util::decode,
     Error, Result,
 };
 
@@ -32,7 +31,7 @@ const RECV_QUEUE_SIZE: usize = 128;
 /// Per-peer wire abstraction. Hides single-pipe (TCP/TLS) vs.
 /// stream-mux (QUIC) framing from the layers above.
 #[async_trait]
-pub(crate) trait PeerConnection: Send + Sync {
+pub(crate) trait Wire: Send + Sync {
     /// Send pre-encoded payload bytes for `proto_id`.
     async fn send(&self, proto_id: &ProtocolID, payload: Vec<u8>) -> Result<()>;
     /// Pop the next event for `proto_id`. Blocks until a message
@@ -43,7 +42,7 @@ pub(crate) trait PeerConnection: Send + Sync {
     async fn shutdown(&self) -> Result<()>;
 }
 
-/// Build the right `PeerConnection` for the post-handshake `QueuedConn`.
+/// Build the right `Wire` for the post-handshake `QueuedConn`.
 /// Picks `MuxConnection` when QUIC is in use, `SingleConnection` otherwise.
 pub(crate) async fn from_queued(
     queued: QueuedConn,
@@ -51,11 +50,11 @@ pub(crate) async fn from_queued(
     proto_ids: impl IntoIterator<Item = ProtocolID> + Clone,
     task_group: &TaskGroup,
     stop_chan: Sender<Result<()>>,
-) -> Result<Arc<dyn PeerConnection>> {
+) -> Result<Arc<dyn Wire>> {
     #[cfg(feature = "quic")]
     if queued.quic_conn.is_some() {
         let conn = MuxConnection::from_queued(queued, negotiated, proto_ids, task_group).await?;
-        return Ok(Arc::new(conn) as Arc<dyn PeerConnection>);
+        return Ok(Arc::new(conn) as Arc<dyn Wire>);
     }
 
     let _ = negotiated;
@@ -92,7 +91,7 @@ impl SingleConnection {
 }
 
 #[async_trait]
-impl PeerConnection for SingleConnection {
+impl Wire for SingleConnection {
     async fn send(&self, proto_id: &ProtocolID, payload: Vec<u8>) -> Result<()> {
         let proto_msg = ProtocolMsg {
             protocol_id: proto_id.clone(),
@@ -168,7 +167,7 @@ impl MuxConnection {
 
 #[cfg(feature = "quic")]
 #[async_trait]
-impl PeerConnection for MuxConnection {
+impl Wire for MuxConnection {
     async fn send(&self, proto_id: &ProtocolID, payload: Vec<u8>) -> Result<()> {
         let proto_msg = ProtocolMsg {
             protocol_id: proto_id.clone(),

--- a/p2p/src/peer/mod.rs
+++ b/p2p/src/peer/mod.rs
@@ -25,7 +25,7 @@ use crate::{
 
 pub use peer_id::PeerID;
 
-use connection::PeerConnection;
+use connection::Wire;
 
 #[derive(Clone, Debug)]
 pub enum ConnDirection {
@@ -42,17 +42,16 @@ impl fmt::Display for ConnDirection {
     }
 }
 
-/// A connected peer. Holds a `PeerConnection` that hides the wire
-/// shape (single framed pipe vs. per-protocol streams).
+/// A connected peer. Holds a `Wire` that hides the wire shape
+/// (single framed pipe vs. per-protocol streams).
 pub struct Peer {
-    own_id: PeerID,
     id: PeerID,
     peer_pool: Weak<PeerPool>,
 
     direction: ConnDirection,
     remote_endpoint: Endpoint,
 
-    connection: Arc<dyn PeerConnection>,
+    connection: Arc<dyn Wire>,
     disconnect_signal: Sender<Result<()>>,
 
     negotiated_protocols: HashSet<ProtocolID>,
@@ -77,10 +76,6 @@ impl Peer {
 
     pub fn id(&self) -> &PeerID {
         &self.id
-    }
-
-    pub fn own_id(&self) -> &PeerID {
-        &self.own_id
     }
 
     pub fn config(&self) -> Arc<Config> {
@@ -171,7 +166,6 @@ impl Peer {
         negotiated_protocols: HashSet<ProtocolID>,
         protocol_ids: impl IntoIterator<Item = ProtocolID> + Clone,
     ) -> Result<Arc<Self>> {
-        let own_id = peer_pool.id.clone();
         let config = peer_pool.config.clone();
         let executor = peer_pool.executor.clone();
         let task_group = TaskGroup::with_executor(executor.clone());
@@ -192,7 +186,6 @@ impl Peer {
 
         let peer_pool_weak = Arc::downgrade(&peer_pool);
         Ok(Arc::new(Peer {
-            own_id,
             id,
             peer_pool: peer_pool_weak,
             direction,

--- a/p2p/tests/access_control.rs
+++ b/p2p/tests/access_control.rs
@@ -83,7 +83,7 @@ fn denied_peer_never_joins_pool() {
         // Built first so its id can go on node_a's deny list.
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -127,7 +127,7 @@ fn allowed_peer_joins_pool() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -178,7 +178,7 @@ fn denied_endpoint_rejected_before_handshake() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),

--- a/p2p/tests/multi_transport.rs
+++ b/p2p/tests/multi_transport.rs
@@ -34,7 +34,7 @@ fn tcp_and_tls_coexist() {
 
         let tcp_client = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{tcp_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{tcp_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -66,7 +66,7 @@ fn tcp_and_tls_coexist() {
 
         let tls_client = create_node(
             Config {
-                peer_endpoints: vec![format!("tls://127.0.0.1:{tls_port}").parse().unwrap()],
+                dial_peers: vec![format!("tls://127.0.0.1:{tls_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -114,7 +114,7 @@ fn node_listens_on_multiple_transports() {
         // Client connecting via TCP
         let tcp_client = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{tcp_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{tcp_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -132,7 +132,7 @@ fn node_listens_on_multiple_transports() {
         // Client connecting via TLS
         let tls_client = create_node(
             Config {
-                peer_endpoints: vec![format!("tls://127.0.0.1:{tls_port}").parse().unwrap()],
+                dial_peers: vec![format!("tls://127.0.0.1:{tls_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),

--- a/p2p/tests/tcp.rs
+++ b/p2p/tests/tcp.rs
@@ -29,7 +29,7 @@ fn two_nodes_direct_connect() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -188,7 +188,7 @@ fn peer_disconnect_detection() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -245,7 +245,7 @@ fn multiple_peers_connect() {
         for i in 0..3 {
             let client = create_node(
                 Config {
-                    peer_endpoints: vec![connect_ep.clone()],
+                    dial_peers: vec![connect_ep.clone()],
                     ..fast_config()
                 },
                 ex.clone(),

--- a/p2p/tests/tls.rs
+++ b/p2p/tests/tls.rs
@@ -29,7 +29,7 @@ fn two_nodes_direct_connect() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tls://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),

--- a/swarm/tests/swarm.rs
+++ b/swarm/tests/swarm.rs
@@ -121,7 +121,7 @@ fn heterogeneous_protocols_connect() {
         // Node B: only ChatProto (no FileProto)
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -188,7 +188,7 @@ fn swarm_membership() {
         // Node B: Chat only
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),
@@ -371,7 +371,7 @@ fn swarm_peer_removal() {
 
         let node_b = create_node(
             Config {
-                peer_endpoints: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
+                dial_peers: vec![format!("tcp://127.0.0.1:{listen_port}").parse().unwrap()],
                 ..fast_config()
             },
             ex.clone(),


### PR DESCRIPTION
- drop unused Peer::own_id field and accessor
- rename private trait PeerConnection to Wire
- rename Config::peer_endpoints to dial_peers
- gate quic-only imports in peer/connection.rs
- add check-examples Makefile target